### PR TITLE
Use Cypress-compatible time formats in QRDA Cat 3 file

### DIFF
--- a/app/assets/stylesheets/account.css.scss
+++ b/app/assets/stylesheets/account.css.scss
@@ -1,4 +1,3 @@
-@import "button.css";
 @import "mixins";
 
 body.login {

--- a/app/views/measures/qrda_cat3.xml.erb
+++ b/app/views/measures/qrda_cat3.xml.erb
@@ -35,7 +35,7 @@
   <!-- SHALL have 1..* author. MAY be device or person. 
     The author of the CDA document in this example is a device at a data submission vendor/registry. -->
   <author>
-    <time value="<%= Time.now.to_s %>"/>
+    <time value="<%= Time.now.to_s(:qrda) %>"/>
     <assignedAuthor>
       <!-- Registry author ID -->
       <id extension="Cypress" root="MITRE"/>
@@ -68,7 +68,7 @@
   <!-- SHALL -->
   <legalAuthenticator>
     <!-- SHALL -->
-    <time value="<%= Time.now.to_s %>"/>
+    <time value="<%= Time.now.to_s(:qrda) %>"/>
     <!-- SHALL -->
     <signatureCode code="S"/>
     <assignedEntity>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:qrda] = '%Y%m%d'


### PR DESCRIPTION
This commit modifies the QRDA Cat 3 export file to use time formats that are compatible with Cypress. Prior to this change, Cypress complains about the author and legal authenticator time formats not matching a given regex.
