### PR TITLE
Remove import of non-existent button.css

### DIFF
--- a/app/assets/stylesheets/account.css.scss
+++ b/app/assets/stylesheets/account.css.scss
@@ -1,4 +1,3 @@
-@import "button.css";
 @import "mixins";
 
 body.login {


### PR DESCRIPTION
This commit resolves issue #40 by removing the import of button.css (which doesn't exist) from the account stylesheet.
