### PR TITLE
change reporting period in UI to 1 year

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,19 +5,19 @@ class ApplicationController < ActionController::Base
   layout :layout_by_resource
   before_filter :set_effective_date
   before_filter :check_ssl_used
-  
+
   add_breadcrumb APP_CONFIG['practice_name'], :root_url
-  
+
   # lock it down!
   check_authorization :unless => :devise_controller?
-  
+
   private
 
   # Overwriting the sign_out redirect path method
   def after_sign_out_path_for(resource_or_scope)
     "#{Rails.configuration.relative_url_root}/logout.html"
   end
-  
+
   def hash_document
     d = Digest::SHA1.new
     checksum = d.hexdigest(response.body)
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
       "application"
     end
   end
-  
+
   rescue_from CanCan::AccessDenied do |exception|
     redirect_to "#{root_url}403.html", :alert => exception.message
   end
@@ -47,13 +47,13 @@ class ApplicationController < ActionController::Base
     end
     @period_start = calc_start(@effective_date)
   end
-  
+
   def calc_start(date)
-    3.months.ago(Time.at(date))
+    1.year.ago(Time.at(date))
   end
-  
+
   def check_ssl_used
-    unless APP_CONFIG['force_unsecure_communications'] or request.ssl? 
+    unless APP_CONFIG['force_unsecure_communications'] or request.ssl?
       redirect_to "#{root_url}no_ssl_warning.html", :alert => "You should be using ssl"
     end
   end

--- a/test/functional/measures_controller_test.rb
+++ b/test/functional/measures_controller_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 include Devise::TestHelpers
 
 class MeasuresControllerTest < ActionController::TestCase
-  
+
   setup do
     dump_database
     collection_fixtures 'measures', 'selected_measures', 'records'
     @user = Factory(:user_w_selected_measures)
-    
+
     @selected_measure = @user.selected_measures.first
     @result = {"measure_id" => @selected_measure['id'],
                "sub_id" => @selected_measure['subs'].first,
@@ -19,13 +19,13 @@ class MeasuresControllerTest < ActionController::TestCase
                "exclusions" => 0 }
     sign_in @user
   end
-  
+
   test "GET 'definition'" do
     get :definition, :id => '0013'
     assert_response :success
     assert_not_nil assigns(:definition)
   end
-  
+
   test "dashboard" do
     get :index
     assert_response :success
@@ -33,12 +33,27 @@ class MeasuresControllerTest < ActionController::TestCase
     # assert_not_nil assigns(:core_alt_measures)
     # assert_not_nil assigns(:alt_measures)
   end
-  
+
   test "period" do
-    get :period, effective_date: "12/31/10", format: :js
+    get :period, effective_date: "12/31/2010", format: :js
+    assert_equal Time.utc(2010,12,31).to_i, assigns(:effective_date)
     assert_response :success
   end
-  
+
+  test "effective_date" do
+    get :period, effective_date: "12/31/2010", persist: "true", format: :js
+    get :index
+    assert_equal Time.utc(2010,12,31).to_i, assigns(:effective_date)
+    assert_response :success
+  end
+
+  test "period_start" do
+    get :period, effective_date: "12/31/2010", persist: "true", format: :js
+    get :index
+    assert_equal Time.utc(2009,12,31).to_i, Time.at(assigns(:period_start)).to_i
+    assert_response :success
+  end
+
   test "measure report for practice" do
 
     @controller.define_singleton_method(:extract_result) do |id, sub_id, effective_date, providers|
@@ -58,14 +73,14 @@ class MeasuresControllerTest < ActionController::TestCase
       @user.stubs(registry_id: '1234')
       @user.stubs(npi: '456')
       @user.stubs(tin: '789')
-      
+
       @controller.define_singleton_method(:extract_result) do |id, sub_id, effective_date, providers|
         { :id => id, :sub_id => sub_id, :population => 5,
           :denominator => 4, :numerator => 2,
           :exclusions => 0
         }
       end
-      
+
       get :measure_report, :format => :xml, :type => "provider"
       assert_response :success
       d = Digest::SHA1.new
@@ -74,7 +89,7 @@ class MeasuresControllerTest < ActionController::TestCase
       assert_not_nil l
       assert_equal @user.username, l.username
   end
-  
+
   test "view measure page" do
     QME::QualityReport.any_instance.stubs(:result).returns(@result)
     get :show, id: @selected_measure['id'], format: :html
@@ -82,14 +97,14 @@ class MeasuresControllerTest < ActionController::TestCase
     assert_not_nil assigns(:result)
     assert_response :success
   end
-  
+
   test "get measure report" do
     QME::QualityReport.any_instance.stubs(:result).returns(@result)
     QME::QualityReport.any_instance.stubs(:calculated?).returns(true)
     get :show, id: @selected_measure['id'], format: :json
     assert_response :success
   end
-  
+
   test "provider pagination" do
     provider_count = 5
     provider_count.times { Factory(:provider) }
@@ -97,11 +112,11 @@ class MeasuresControllerTest < ActionController::TestCase
     assert_not_nil assigns(:providers)
     assert_response :success
   end
-  
+
  test "get providers json uncalculated" do
    provider_count = 5
    provider_count.times { Factory(:provider) }
-   
+
    QME::QualityReport.any_instance.expects(:result).never
    QME::QualityReport.any_instance.stubs(:calculated?).returns(false).times(provider_count)
    QME::QualityReport.any_instance.stubs(:calculate).returns("UUID")
@@ -110,11 +125,11 @@ class MeasuresControllerTest < ActionController::TestCase
 
    xhr :get, :providers, id: @selected_measure['id'], :format => :json, :provider => @providers.map(&:id)
  end
-  
+
   test "get providers calculated" do
     provider_count = 5
     provider_count.times { Factory(:provider) }
-    
+
     QME::QualityReport.any_instance.stubs(:result).returns(@result).times(provider_count)
     QME::QualityReport.any_instance.stubs(:calculated?).returns(true).times(provider_count)
 
@@ -122,16 +137,16 @@ class MeasuresControllerTest < ActionController::TestCase
 
     xhr :get, :providers, id: @selected_measure['id'], :format => :json, :provider => @providers.map(&:id)
   end
-  
+
   test "measure patients" do
     get :measure_patients, id: @selected_measure['id']
     assert_response :success
   end
-  
+
   test "patient list" do
     5.times { Factory(:record) }
     get :patient_list, id: @selected_measure['id'], format: :xml
   end
-  
+
 end
-  
+


### PR DESCRIPTION
Currently certification is conducted against a 1 year measurement and reporting period, which is reflected in measure bundle 2.3.0.

Per: http://jira.oncprojectracking.org/browse/CQM-480

"For purposes of reporting to CMS, the reporting period = the measurement period.

So, if a provider is in the first year of demonstrating MU and has selected a reporting period of any 90 consecutive days (during the CY for EPs or during the FY for EHs), then the 90-consecutive day reporting period is also the measurement period they should use for reporting eCQMs.

If a provider is selecting a quarter reporting period (again, CY or FY quarter depending on whether the provider is an EP or EH), then the quarter reporting period is also the measurement period they should use for reporting eCQMs.

If a provider is using a full year reporting period (again, CY or FY depending on whether the provider is an EP or EH), then the full year reporting period is also the measurement period they should use for reporting eCQMs."
