### PR TITLE
Fixes bug where CDAs with inlined sdtc attributes cause crashes

### DIFF
--- a/lib/record_importer.rb
+++ b/lib/record_importer.rb
@@ -55,6 +55,7 @@ class RecordImporter
     
     if root_element_name == 'ClinicalDocument'
       doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+      doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
 
       if doc.at_xpath("/cda:ClinicalDocument/cda:templateId[@root='2.16.840.1.113883.3.88.11.32.1']")
         patient_data = HealthDataStandards::Import::C32::PatientImporter.instance.parse_c32(doc)

--- a/test/fixtures/cat1_with_sdtc_inlined.xml
+++ b/test/fixtures/cat1_with_sdtc_inlined.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type='text/xsl' href='CDA.xsl'?>
+<ClinicalDocument  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc" >
+  <realmCode code="US" />
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <templateId root="2.16.840.1.113883.10.20.24.1.1" />
+  <templateId root="2.16.840.1.113883.10.20.24.1.2" />
+  <id assigningAuthorityName="EPC" extension="4bca62ca-3d81-11e3-8ecc-460231621f93" root="1.2.840.114350.1.13.327.1.7.1.1" />
+  <code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="QRDA Category I – Single Patient Report" />
+  <title>Quality Measure Report (Patient Level)</title>
+  <effectiveTime value="20131025092528" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" />
+  <languageCode code="en-US" />
+  <recordTarget>
+    <patientRole>
+      <id extension="395-73-5097" root="2.16.840.1.113883.4.1" />
+      <addr use="HP">
+        <streetAddressLine nullFlavor="UNK" />
+        <city nullFlavor="UNK" />
+      </addr>
+      <telecom nullFlavor="UNK" />
+      <patient>
+        <name>
+          <given>crash</given>
+          <family>Btw</family>
+        </name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" />
+        <birthTime value="19631025" />
+        <ethnicGroupCode codeSystem="2.16.840.1.113883.6.238" nullFlavor="UNK" />
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <legalAuthenticator>
+    <time value="20131025092528-0500" />
+    <signatureCode code="S" />
+    <assignedEntity>
+      <id extension="1000001143" root="2.16.840.1.113883.4.6" />
+      <telecom use="WP" />
+      <assignedPerson>
+        <name>
+          <given>MUHAMMAD</given>
+          <family>BTW AL-KHWARIZMI</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id extension="1" root="1.2.840.114350.1.13.327.1.7.2.696570" />
+        <name>CDE FACILITY</name>
+        <telecom use="WP" value="tel:+1-404-777-8000" />
+        <addr nullFlavor="UNK" />
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.17.2.4" />
+          <templateId root="2.16.840.1.113883.10.20.24.2.1" />
+          <code code="55188-7" codeSystem="2.16.840.1.113883.6.1" />
+
+          <entry>
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <templateId root="2.16.840.1.113883.10.20.24.3.23"/>
+              <id root="1.3.6.1.4.1.115" extension="512ba7eae7e915f677000003"/>
+              <code code="112689000" codeSystem="2.16.840.1.113883.6.96" sdtc:valueSet="2.16.840.1.113883.3.666.5.625" xmlns:sdtc="urn:hl7-org:sdtc"><originalText>Encounter, Performed: Hospital 
+
+Measures-Encounter Inpatient (Code List: 2.16.840.1.113883.3.666.5.625)</originalText></code>
+              <text>Encounter, Performed: Hospital Measures-Encounter Inpatient (Code List: 
+
+2.16.840.1.113883.3.666.5.625)</text>
+              <statusCode code="completed"/>
+              <effectiveTime>
+                <low value='20061121075239'/>
+                <high value='20061122012933'/>
+              </effectiveTime>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/functional/records_controller_test.rb
+++ b/test/functional/records_controller_test.rb
@@ -11,6 +11,7 @@ class RecordsControllerTest < ActionController::TestCase
     @body2 = File.new("test/fixtures/patient_sample.xml").read
     @ccr_body = File.new("test/fixtures/sample_ccr.xml").read
     @cat1_body = File.new("test/fixtures/sample_cat1.xml").read
+    @cat1_inlined = File.new("test/fixtures/cat1_with_sdtc_inlined.xml").read
     sign_in @user
   end
   
@@ -78,6 +79,11 @@ class RecordsControllerTest < ActionController::TestCase
     assert_equal 7, created_record.encounters.count
   end
   
+  test "create record with QRDA Cat 1 with inlined sdtc attributes" do
+    raw_post(:create, @cat1_inlined)
+    assert_response(201)
+  end
+
   test "replace existing record" do
     # create one record
     raw_post(:create, @body)


### PR DESCRIPTION
RecordImporter in popHealth needs to register the sdtc namespace
prefix when XML documents are uploaded. health-data-standards
importers expect a Nokogiri document that has all of the namespace
prefixes set up. In the RecordImporter, we were setting up the cda
namespace prefix, but not the sdtc one. I think that on most
documents, we could get away with that because Nokogiri will support
any namespace prefixes that are declared in the start of the document.
By registering the prefix, it fixes this bug.
