### PR TITLE
update measure view to display population chart & performance rate

### DIFF
--- a/app/assets/javascripts/templates/measures/show.hbs
+++ b/app/assets/javascripts/templates/measures/show.hbs
@@ -1,13 +1,11 @@
 <div class="left-sidebar" id="measureSummary">
-    <div>
-          <input type="text" value="80" class="dial">
-    </div>
-    <div class="fraction-listing">
-      <div class="numerator">{{numerator}}</div>
-      <div class="denominator">{{performanceDenominator}}</div>
-    </div>
-    <div id="test" class="popChart">
-        
-    </div>
-
+  <div>
+    {{! TODO move this into a partial? }}
+    <input type="text" value="80" class="dial" data-readOnly="true" data-width="80" data-height="80" data-thickness=".1" data-fgColor="#4B979D" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif">
+  </div>
+  <div class="fraction-listing">
+    <div class="numerator">{{numerator}}</div>
+    <div class="denominator">{{performanceDenominator}}</div>
+  </div>
+  <div id="test" class="pop-chart"></div>
 </div>

--- a/app/assets/javascripts/views/measure.js.coffee
+++ b/app/assets/javascripts/views/measure.js.coffee
@@ -2,10 +2,10 @@ class Thorax.Views.MeasureView extends Thorax.View
   template: JST['measures/show']
   events:
     rendered: ->
-      @$(".dial").knob({width: 75, readOnly: true, thickness:.1 ,inputColor:"#37858D", fgColor:"#37858D"})
-      myChart = populationChart()
-      select = d3.select("#test")
-        .datum({patients: 15, NUMER:5, DENOM:7, DENEX:2, DENEXC:6})
+      @$('.dial').knob()
+      myChart = PopHealth.viz.populationChart().width(125).height(50).numerSpacing(2).maximumValue(PopHealth.patientCount)
+      select = d3.select(@el).select('#test')
+        .datum(NUMER: 5, DENOM: 7, DENEX: 2, DENEXCEP: 6)
         .call(myChart)
-      
-    
+
+

--- a/app/assets/stylesheets/styles.css.less
+++ b/app/assets/stylesheets/styles.css.less
@@ -82,22 +82,6 @@
       }
     }
 
-    .pop-chart {
-      height: 50px;
-      width: 125px;
-      rect{
-        stroke:white;
-        stroke-width:0px;
-        fill: rgb(205,205,205);
-      }
-      .numer {
-        fill: rgb(59,133,140);
-      }
-      .denom {
-        fill: rgb(59,133,140);
-      }
-    }
-
     .patient-btn {
       text-transform: uppercase;
     }
@@ -106,7 +90,21 @@
 
 
 
-
+.pop-chart {
+  height: 50px;
+  width: 125px;
+  rect{
+    stroke:white;
+    stroke-width:0px;
+    fill: rgb(205,205,205);
+  }
+  .numer {
+    fill: rgb(59,133,140);
+  }
+  .denom {
+    fill: rgb(59,133,140);
+  }
+}
 
 
 // New styles for side bar for the measure view/patient list


### PR DESCRIPTION
This fixes the issue that's keeping the measure page from rendering successfully at the moment. We should also add tests to this too, but it's still using test data/fake divs (like "#test"), so this is still a work in progress.
