### PR TITLE
add initial support for initial scrolling

### DIFF
--- a/app/assets/javascripts/models/patient_result.js.coffee
+++ b/app/assets/javascripts/models/patient_result.js.coffee
@@ -7,4 +7,8 @@ class Thorax.Models.PatientResult extends Thorax.Model
 class Thorax.Collections.PatientResults extends Thorax.Collection
   model: Thorax.Models.PatientResult
   url: -> "#{@parent.url()}/patient_results"
-  initialize: (attrs, options) -> @parent = options.parent
+  initialize: (attrs, options) ->
+    @parent = options.parent
+    @page = 1
+  fetchNextPage: (options = {perPage: 10}) ->
+    @fetch remove: false, data: {page: ++@page, per_page: options.perPage}

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -1,18 +1,32 @@
 class Thorax.Views.PatientResultsView extends Thorax.View
   template: JST['patient_results/index']
+  fetchTriggerPoint: 500 # fetch data when we're 500 pixels away from the bottom
   patientContext: (patient) ->
     _(patient.toJSON()).extend
       formatted_birthdate: moment(patient.get('birthdate')).format('MM/DD/YYYY') if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
 
+  events:
+    'change:load-state': (state) -> @isFetching = false if state is 'end'
+    rendered: ->
+      $(document).on 'scroll', @scrollHandler
+    destroyed: ->
+      $(document).off 'scroll', @scrollHandler
+
   initialize: ->
+    @isFetching = false
+    @scrollHandler = =>
+      distanceToBottom = $(document).height() - $(window).scrollTop() - $(window).height()
+      if !@isFetching and @query.get('patient_results')?.length and @fetchTriggerPoint > distanceToBottom
+        @isFetching = true
+        @query.get('patient_results').fetchNextPage()
     @filterPopulation = 'DENOM'
-    @query.on 'change', => 
-      @setCollection(@query.get('patient_results'), {render: true})
+    @query.on 'change', =>
+      @setCollection(@query.get('patient_results'), render: true)
       @query.get('patient_results').fetch()
     if @query.isNew()
-      @query.fetch() 
-    else 
+      @query.fetch()
+    else
       @setCollection(@query.get('patient_results'))
       @query.get('patient_results').fetch()
 
@@ -34,9 +48,9 @@ class Thorax.Views.QueryView extends Thorax.View
   initialize: (attrs) ->
     @setModel(attrs.model, {render: true})
     @parent = attrs.parent
-  
+
   events:
-    'click .population-btn': 'changeFilter' 
+    'click .population-btn': 'changeFilter'
 
   changeFilter: (event) ->
     @parent.changePopulation event.currentTarget.id

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -5,7 +5,7 @@ module PaginationHelper
     set_pagination_params
     count = collection.count
     links = generate_links(base_url,count,@per_page,@page)
-    response.headers["Link"] = links.join(",") if !links.empty? 
+    response.headers["Link"] = links.join(",") if !links.empty?
     collection.skip(@offset).limit(@per_page)
   end
 
@@ -18,7 +18,7 @@ module PaginationHelper
 
     links << generate_link(base_url,1,per_page,"first") if total_pages > 1
     links << generate_link(base_url,total_pages,per_page,"last") if total_pages != 1
-    links << generate_link(base_url,page-1,per_page,"prev") if prev_page 
+    links << generate_link(base_url,page-1,per_page,"prev") if prev_page
     links << generate_link(base_url,page+1,per_page,"next") if next_page
     links
   end
@@ -28,8 +28,8 @@ module PaginationHelper
   end
 
   def set_pagination_params
-    @page = params[:page] || 1
-    @per_page = params[:per_page] || 100
+    @page = (params[:page] || 1).to_i
+    @per_page = (params[:per_page] || 100).to_i
     @per_page = 100 if @per_page > 100
     @offset = (@page-1)*@per_page
   end

--- a/spec/javascripts/fixtures/json/queries/patient_results.json
+++ b/spec/javascripts/fixtures/json/queries/patient_results.json
@@ -1,0 +1,338 @@
+[
+  {
+    "value": {
+      "DENEX": 0,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 0,
+      "OBSERV": null,
+      "_id": "5293ed2001fbdfb6f6000003",
+      "antinumerator": 0,
+      "birthdate": 259736400,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Paul",
+      "gender": "M",
+      "languages": [
+        "eng"
+      ],
+      "last": "Hewson",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "505327621A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a000084",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a000089",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a000082"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  },
+  {
+    "value": {
+      "DENEX": 0,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 0,
+      "OBSERV": null,
+      "_id": "5293eddb01fbdfb6f6000004",
+      "antinumerator": 1,
+      "birthdate": -880916400,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Dean",
+      "gender": "M",
+      "languages": [
+        "eng"
+      ],
+      "last": "Holloway",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "505327622A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a00008d",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a0000a2",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a00008b"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  },
+  {
+    "value": {
+      "DENEX": 0,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 1,
+      "OBSERV": null,
+      "_id": "5293eddc01fbdfb6f6000050",
+      "antinumerator": 0,
+      "birthdate": -880916400,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Jonathan",
+      "gender": "M",
+      "languages": [
+        "eng"
+      ],
+      "last": "Murray",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "828914689A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a00002c",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a000045",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a00002a"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  },
+  {
+    "value": {
+      "DENEX": 1,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 0,
+      "OBSERV": null,
+      "_id": "5293eddc01fbdfb6f6000051",
+      "antinumerator": 0,
+      "birthdate": -1041274800,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Patsy",
+      "gender": "F",
+      "languages": [
+        "eng"
+      ],
+      "last": "Parsons",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "795776002A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a000049",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a000054",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a000047"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  },
+  {
+    "value": {
+      "DENEX": 1,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 0,
+      "OBSERV": null,
+      "_id": "5293eddc01fbdfb6f6000052",
+      "antinumerator": 0,
+      "birthdate": -1041274800,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Lucille",
+      "gender": "F",
+      "languages": [
+        "eng"
+      ],
+      "last": "Butler",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "795776003A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a000058",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a000063",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a000056"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  },
+  {
+    "value": {
+      "DENEX": 0,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 1,
+      "OBSERV": null,
+      "_id": "5293eddc01fbdfb6f6000053",
+      "antinumerator": 0,
+      "birthdate": -880916400,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Ryan",
+      "gender": "M",
+      "languages": [
+        "eng"
+      ],
+      "last": "Swanson",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "505327620A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a000067",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a000080",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a000065"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  },
+  {
+    "value": {
+      "DENEX": 0,
+      "DENEXCEP": 0,
+      "DENOM": 1,
+      "IPP": 1,
+      "MSRPOPL": null,
+      "NUMER": 0,
+      "OBSERV": null,
+      "_id": "5293eddc01fbdfb6f6000054",
+      "antinumerator": 1,
+      "birthdate": -880916400,
+      "effective_date": 1356998340,
+      "ethnicity": null,
+      "filters": null,
+      "first": "Eugene",
+      "gender": "M",
+      "languages": [
+        "eng"
+      ],
+      "last": "Casey",
+      "logger": [
+
+      ],
+      "manual_exclusion": false,
+      "measure_id": "40280381-3D61-56A7-013E-66BC02DA4DEE",
+      "medical_record_id": "505327623A",
+      "nqf_id": "0018",
+      "patient_id": "525d98f501fbdf993a0000a6",
+      "payer": {
+
+      },
+      "provider_performances": [
+        {
+          "_id": "525d98f501fbdf993a0000bb",
+          "start_date": 1026792000,
+          "end_date": 1381204800,
+          "provider_id": "525d98f501fbdf993a0000a4"
+        }
+      ],
+      "race": null,
+      "rationale": {
+
+      },
+      "sub_id": null,
+      "test_id": null
+    }
+  }
+]

--- a/spec/javascripts/models/patient_results.spec.js.coffee
+++ b/spec/javascripts/models/patient_results.spec.js.coffee
@@ -1,0 +1,12 @@
+describe 'PatientResults', ->
+  describe 'Collection', ->
+    beforeEach ->
+      @json = getJSONFixture 'queries/patient_results.json'
+      jasmine.Ajax.useMock()
+      @collection = new Thorax.Collections.PatientResults @json[0...2], parse: true, parent: jasmine.createSpyObj('parent', ['url'])
+
+    it 'can fetch additional pages', ->
+      @collection.fetchNextPage(perPage: 2)
+      mostRecentAjaxRequest().response {responseText: JSON.stringify(@json[2...4]), status: 200}
+      expect(@collection.toJSON()).toEqual _(@json[0...4]).map (r) -> r.value
+      expect(@collection.page).toEqual 2

--- a/spec/javascripts/vendor/mock-ajax.js
+++ b/spec/javascripts/vendor/mock-ajax.js
@@ -1,0 +1,199 @@
+/*
+ Jasmine-Ajax : a set of helpers for testing AJAX requests under the Jasmine
+ BDD framework for JavaScript.
+
+ Supports jQuery.
+
+ http://github.com/pivotal/jasmine-ajax
+
+ Jasmine Home page: http://pivotal.github.com/jasmine
+
+ Copyright (c) 2008-2013 Pivotal Labs
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+// Jasmine-Ajax interface
+var ajaxRequests = [];
+
+function mostRecentAjaxRequest() {
+  if (ajaxRequests.length > 0) {
+    return ajaxRequests[ajaxRequests.length - 1];
+  } else {
+    return null;
+  }
+}
+
+function clearAjaxRequests() {
+  ajaxRequests = [];
+}
+
+// Fake XHR for mocking Ajax Requests & Responses
+function FakeXMLHttpRequest() {
+  var extend = Object.extend || jQuery.extend;
+  extend(this, {
+    requestHeaders: {},
+
+    open: function() {
+      this.method = arguments[0];
+      this.url = arguments[1];
+      this.username = arguments[3];
+      this.password = arguments[4];
+      this.readyState = 1;
+    },
+
+    setRequestHeader: function(header, value) {
+      this.requestHeaders[header] = value;
+    },
+
+    abort: function() {
+      this.readyState = 0;
+    },
+
+    readyState: 0,
+
+    onload: function() {
+    },
+
+    onreadystatechange: function(isTimeout) {
+    },
+
+    status: null,
+
+    send: function(data) {
+      this.params = data;
+      this.readyState = 2;
+    },
+
+    data: function() {
+      var data = {};
+      if (typeof this.params !== 'string') return data;
+      var params = this.params.split('&');
+
+      for (var i = 0; i < params.length; ++i) {
+        var kv = params[i].replace(/\+/g, ' ').split('=');
+        var key = decodeURIComponent(kv[0]);
+        data[key] = data[key] || [];
+        data[key].push(decodeURIComponent(kv[1]));
+        data[key].sort();
+      }
+      return data;
+    },
+
+    getResponseHeader: function(name) {
+      return this.responseHeaders[name];
+    },
+
+    getAllResponseHeaders: function() {
+      var responseHeaders = [];
+      for (var i in this.responseHeaders) {
+        if (this.responseHeaders.hasOwnProperty(i)) {
+          responseHeaders.push(i + ': ' + this.responseHeaders[i]);
+        }
+      }
+      return responseHeaders.join('\r\n');
+    },
+
+    responseText: null,
+
+    response: function(response) {
+      this.status = response.status;
+      this.responseText = response.responseText || "";
+      this.readyState = 4;
+      this.responseHeaders = response.responseHeaders ||
+      {"Content-type": response.contentType || "application/json" };
+      // uncomment for jquery 1.3.x support
+      // jasmine.Clock.tick(20);
+
+      this.onload();
+      this.onreadystatechange();
+    },
+    responseTimeout: function() {
+      this.readyState = 4;
+      jasmine.Clock.tick(jQuery.ajaxSettings.timeout || 30000);
+      this.onreadystatechange('timeout');
+    }
+  });
+
+  return this;
+}
+
+
+jasmine.Ajax = {
+
+  isInstalled: function() {
+    return jasmine.Ajax.installed === true;
+  },
+
+  assertInstalled: function() {
+    if (!jasmine.Ajax.isInstalled()) {
+      throw new Error("Mock ajax is not installed, use jasmine.Ajax.useMock()");
+    }
+  },
+
+  useMock: function() {
+    if (!jasmine.Ajax.isInstalled()) {
+      var spec = jasmine.getEnv().currentSpec;
+      spec.after(jasmine.Ajax.uninstallMock);
+
+      jasmine.Ajax.installMock();
+    }
+  },
+
+  installMock: function() {
+    if (typeof jQuery != 'undefined') {
+      jasmine.Ajax.installJquery();
+    } else {
+      throw new Error("jasmine.Ajax currently only supports jQuery");
+    }
+    jasmine.Ajax.installed = true;
+  },
+
+  installJquery: function() {
+    jasmine.Ajax.mode = 'jQuery';
+    jasmine.Ajax.real = jQuery.ajaxSettings.xhr;
+    jQuery.ajaxSettings.xhr = jasmine.Ajax.jQueryMock;
+
+  },
+
+  uninstallMock: function() {
+    jasmine.Ajax.assertInstalled();
+    if (jasmine.Ajax.mode == 'jQuery') {
+      jQuery.ajaxSettings.xhr = jasmine.Ajax.real;
+    }
+    jasmine.Ajax.reset();
+  },
+
+  reset: function() {
+    jasmine.Ajax.installed = false;
+    jasmine.Ajax.mode = null;
+    jasmine.Ajax.real = null;
+  },
+
+  jQueryMock: function() {
+    var newXhr = new FakeXMLHttpRequest();
+    ajaxRequests.push(newXhr);
+    return newXhr;
+  },
+
+  installed: false,
+  mode: null
+};


### PR DESCRIPTION
One initial issue: this implements pagination for the patient results, but because the patient results are currently managed in a single collection, fetches of additional pages return unfiltered results; any filters (for numerator etc) will show up AFTER the results are in, meaning that the user won't see a full page if any of the results have been filtered out. This requires some thought about the design.
