### PR TITLE
Give users the option to mask PHI data from 'Edit Account' screen.

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -12,6 +12,7 @@
 #= require d3/d3
 #
 #= require config
+#= require helpers
 #= require population_chart
 #= require_tree ./templates
 #= require_tree ./models

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -1,8 +1,20 @@
+window.PopHealth ||= {}
+PopHealth.Helpers ||= {}
+
 # Helper for replacing all but the first character of a name with x's 
 # if the user has chosen to mask PHI data in settings.
-Handlebars.registerHelper 'maskName', (value) -> 
+PopHealth.Helpers.maskName = (value) -> 
   maskStatus = PopHealth.currentUser.maskStatus()
   if value && maskStatus
     return value[0]+"xxxxxx"
+  else
+    return value
+
+# Helper used to replace MM/DD/YYYY or MMM DD YYYY with xx/xx/YYYY or
+# xxx xx YYYY if mask PHI data is enabled in settings.
+PopHealth.Helpers.maskDateFormat = (value) ->
+  maskStatus = PopHealth.currentUser.maskStatus()
+  if value && maskStatus
+    return value.replace(/[MD]/g, 'x')
   else
     return value

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -3,7 +3,7 @@
 Handlebars.registerHelper 'maskName', (value) -> 
 	maskStatus = PopHealth.currentUser.maskStatus()
 	if value && maskStatus
-		return value[0]+Array(value.length).join("x")
+		return value[0]+"xxxxxx"
 	else
 		return value
 

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -1,17 +1,8 @@
 # Helper for replacing all but the first character of a name with x's 
 # if the user has chosen to mask PHI data in settings.
 Handlebars.registerHelper 'maskName', (value) -> 
-	maskStatus = PopHealth.currentUser.maskStatus()
-	if value && maskStatus
-		return value[0]+"xxxxxx"
-	else
-		return value
-
-# Helper for replacing all but the year of birth for a patient with x's
-# if the user has chosen to mask PHI data in settings.
-Handlebars.registerHelper 'maskDate', (value) -> 
-	maskStatus = PopHealth.currentUser.maskStatus()
-	if value && maskStatus
-		return value.replace(/[MD]/g, 'x')
-	else
-		return value
+  maskStatus = PopHealth.currentUser.maskStatus()
+  if value && maskStatus
+    return value[0]+"xxxxxx"
+  else
+    return value

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -12,7 +12,6 @@ Handlebars.registerHelper 'maskName', (value) ->
 Handlebars.registerHelper 'maskDate', (value) -> 
 	maskStatus = PopHealth.currentUser.maskStatus()
 	if value && maskStatus
-		value = value.split("/")
-		return "xx/xx/"+value[value.length-1]
+		return value.replace(/[MD]/g, 'x')
 	else
 		return value

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -1,0 +1,18 @@
+# Helper for replacing all but the first character of a name with x's 
+# if the user has chosen to mask PHI data in settings.
+Handlebars.registerHelper 'maskName', (value) -> 
+	maskStatus = PopHealth.currentUser.maskStatus()
+	if value && maskStatus
+		return value[0]+Array(value.length).join("x")
+	else
+		return value
+
+# Helper for replacing all but the year of birth for a patient with x's
+# if the user has chosen to mask PHI data in settings.
+Handlebars.registerHelper 'maskDate', (value) -> 
+	maskStatus = PopHealth.currentUser.maskStatus()
+	if value && maskStatus
+		value = value.split("/")
+		return "xx/xx/"+value[value.length-1]
+	else
+		return value

--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -2,6 +2,8 @@ class Thorax.Models.User extends Thorax.Model
   url: '/users' # no ID necessary, as this corresponds to the currently logged in user
   idAttribute: '_id'
 
+  maskStatus: -> @get('mask_phi_data')
+
   selectedCategories: (categories) ->
     selectedCats = new categories.constructor
     categories.each (cat) =>

--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -2,7 +2,7 @@ class Thorax.Models.User extends Thorax.Model
   url: '/users' # no ID necessary, as this corresponds to the currently logged in user
   idAttribute: '_id'
 
-  maskStatus: -> @get('mask_phi_data')
+  maskStatus: -> @get('preferences').mask_phi_data
 
   selectedCategories: (categories) ->
     selectedCats = new categories.constructor

--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -23,7 +23,7 @@
         <td><strong>{{maskName last}}</strong></td>
         <td>{{maskName first}}</td>
         <td>{{age}}</td>
-        <td>{{formatted_birthdate}}</td>
+        <td>{{formattedBirthdate}}</td>
         <td>{{gender}}</td>
         <td>
           <button class="btn-default">Exclude</button>

--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -20,8 +20,8 @@
         <td>
           {{#link "patients/{{patient_id}}" expand-tokens=true}}{{patient_id}}{{/link}}
         </td>
-        <td><strong>{{maskName last}}</strong></td>
-        <td>{{maskName first}}</td>
+        <td><strong>{{last}}</strong></td>
+        <td>{{first}}</td>
         <td>{{age}}</td>
         <td>{{formattedBirthdate}}</td>
         <td>{{gender}}</td>

--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -23,7 +23,7 @@
         <td><strong>{{maskName last}}</strong></td>
         <td>{{maskName first}}</td>
         <td>{{age}}</td>
-        <td>{{maskDate formatted_birthdate}}</td>
+        <td>{{formatted_birthdate}}</td>
         <td>{{gender}}</td>
         <td>
           <button class="btn-default">Exclude</button>

--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -20,10 +20,10 @@
         <td>
           {{#link "patients/{{patient_id}}" expand-tokens=true}}{{patient_id}}{{/link}}
         </td>
-        <td><strong>{{last}}</strong></td>
-        <td>{{first}}</td>
+        <td><strong>{{maskName last}}</strong></td>
+        <td>{{maskName first}}</td>
         <td>{{age}}</td>
-        <td>{{formatted_birthdate}}</td>
+        <td>{{maskDate formatted_birthdate}}</td>
         <td>{{gender}}</td>
         <td>
           <button class="btn-default">Exclude</button>

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -1,7 +1,7 @@
 <p>
-  Name: {{first}} {{last}}<br>
+  Name: {{maskName first}} {{maskName last}}<br>
   Effective Date: {{formatted_effective_time}}<br>
-  DOB: {{formatted_birthdate}}<br>
+  DOB: {{maskDate formatted_birthdate}}<br>
   Sex: {{gender}}<br>
   Race: {{race.name}}<br>
   Ethnicity: {{ethnicity.name}}<br>

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -1,7 +1,7 @@
 <p>
   Name: {{maskName first}} {{maskName last}}<br>
   Effective Date: {{formatted_effective_time}}<br>
-  DOB: {{maskDate formatted_birthdate}}<br>
+  DOB: {{formatted_birthdate}}<br>
   Sex: {{gender}}<br>
   Race: {{race.name}}<br>
   Ethnicity: {{ethnicity.name}}<br>

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -1,7 +1,7 @@
 <p>
   Name: {{maskName first}} {{maskName last}}<br>
-  Effective Date: {{formatted_effective_time}}<br>
-  DOB: {{formatted_birthdate}}<br>
+  Effective Date: {{formattedEffectiveTime}}<br>
+  DOB: {{formattedBirthdate}}<br>
   Sex: {{gender}}<br>
   Race: {{race.name}}<br>
   Ethnicity: {{ethnicity.name}}<br>

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -1,5 +1,5 @@
 <p>
-  Name: {{maskName first}} {{maskName last}}<br>
+  Name: {{first}} {{last}}<br>
   Effective Date: {{formattedEffectiveTime}}<br>
   DOB: {{formattedBirthdate}}<br>
   Sex: {{gender}}<br>

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -2,7 +2,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   template: JST['patient_results/index']
   patientContext: (patient) ->
     _(patient.toJSON()).extend
-      formattedBirthdate: moment(patient.get('birthdate')).format(maskDate('MM/DD/YYYY')) if patient.get('birthdate')
+      formattedBirthdate: moment(patient.get('birthdate')).format(maskDateFormat('MM/DD/YYYY')) if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
 
   initialize: ->
@@ -23,7 +23,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
     @filterPopulation = population
     @updateFilter()
 
-  maskDate = (value) -> 
+  maskDateFormat = (value) -> 
     maskStatus = PopHealth.currentUser.maskStatus()
     if value && maskStatus
       return value.replace(/[MD]/g, 'x')

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -2,7 +2,9 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   template: JST['patient_results/index']
   patientContext: (patient) ->
     _(patient.toJSON()).extend
-      formattedBirthdate: moment(patient.get('birthdate')).format(maskDateFormat('MM/DD/YYYY')) if patient.get('birthdate')
+      first: PopHealth.Helpers.maskName(patient.get('first')) if patient.get('first')
+      last: PopHealth.Helpers.maskName(patient.get('last')) if patient.get('last')
+      formattedBirthdate: moment(patient.get('birthdate')).format(PopHealth.Helpers.maskDateFormat('MM/DD/YYYY')) if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
 
   initialize: ->
@@ -22,13 +24,6 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   changePopulation: (population) ->
     @filterPopulation = population
     @updateFilter()
-
-  maskDateFormat = (value) -> 
-    maskStatus = PopHealth.currentUser.maskStatus()
-    if value && maskStatus
-      return value.replace(/[MD]/g, 'x')
-    else
-      return value
 
 class Thorax.Views.QueryView extends Thorax.View
   template: JST['patient_results/query']

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -2,7 +2,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   template: JST['patient_results/index']
   patientContext: (patient) ->
     _(patient.toJSON()).extend
-      formatted_birthdate: moment(patient.get('birthdate')).format('MM/DD/YYYY') if patient.get('birthdate')
+      formatted_birthdate: moment(patient.get('birthdate')).format(Handlebars.helpers.maskDate('MM/DD/YYYY')) if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
 
   initialize: ->

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -2,7 +2,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   template: JST['patient_results/index']
   patientContext: (patient) ->
     _(patient.toJSON()).extend
-      formatted_birthdate: moment(patient.get('birthdate')).format(Handlebars.helpers.maskDate('MM/DD/YYYY')) if patient.get('birthdate')
+      formatted_birthdate: moment(patient.get('birthdate')).format(maskDate('MM/DD/YYYY')) if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
 
   initialize: ->
@@ -22,6 +22,13 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   changePopulation: (population) ->
     @filterPopulation = population
     @updateFilter()
+
+  maskDate = (value) -> 
+    maskStatus = PopHealth.currentUser.maskStatus()
+    if value && maskStatus
+      return value.replace(/[MD]/g, 'x')
+    else
+      return value
 
 class Thorax.Views.QueryView extends Thorax.View
   template: JST['patient_results/query']

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -2,7 +2,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
   template: JST['patient_results/index']
   patientContext: (patient) ->
     _(patient.toJSON()).extend
-      formatted_birthdate: moment(patient.get('birthdate')).format(maskDate('MM/DD/YYYY')) if patient.get('birthdate')
+      formattedBirthdate: moment(patient.get('birthdate')).format(maskDate('MM/DD/YYYY')) if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
 
   initialize: ->

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -1,15 +1,12 @@
 class Thorax.Views.PatientView extends Thorax.View
   template: JST['patients/show']
+  first: -> PopHealth.Helpers.maskName @model.get('first')
+
+  last: -> PopHealth.Helpers.maskName @model.get('last')
+
   formattedEffectiveTime: -> formatTime @model.get('effective_time')
 
-  formattedBirthdate: -> formatTime @model.get('birthdate'), maskDateFormat "MM/DD/YYYY"
+  formattedBirthdate: -> formatTime @model.get('birthdate'), PopHealth.Helpers.maskDateFormat "MM/DD/YYYY"
 
   # Helper function for date/time conversion
   formatTime = (time, format) -> moment(time).format(format || 'MM/DD/YYYY') if time
-
-  maskDateFormat = (value) -> 
-    maskStatus = PopHealth.currentUser.maskStatus()
-    if value && maskStatus
-      return value.replace(/[MD]/g, 'x')
-    else
-      return value

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -4,7 +4,7 @@ class Thorax.Views.PatientView extends Thorax.View
   formatted_effective_time: -> format_time @model.get('effective_time')
   # The maskDate helper is called from this file since calling it from the patient show file 
   # causes the format_time function to be printed to the screen instead of a proper result.
-  formatted_birthdate: -> Handlebars.helpers.maskDate format_time @model.get('birthdate')
+  formatted_birthdate: -> format_time @model.get('birthdate'), Handlebars.helpers.maskDate "MM/DD/YYYY"
 
   # Helper function for date/time conversion
-  format_time = (time) -> moment(time).format('MM/DD/YYYY') if time
+  format_time = (time, format) -> moment(time).format(format || 'MM/DD/YYYY') if time

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -1,11 +1,11 @@
 class Thorax.Views.PatientView extends Thorax.View
   template: JST['patients/show']
-  formatted_effective_time: -> format_time @model.get('effective_time')
+  formattedEffectiveTime: -> formatTime @model.get('effective_time')
 
-  formatted_birthdate: -> format_time @model.get('birthdate'), maskDate "MM/DD/YYYY"
+  formattedBirthdate: -> formatTime @model.get('birthdate'), maskDate "MM/DD/YYYY"
 
   # Helper function for date/time conversion
-  format_time = (time, format) -> moment(time).format(format || 'MM/DD/YYYY') if time
+  formatTime = (time, format) -> moment(time).format(format || 'MM/DD/YYYY') if time
 
   maskDate = (value) -> 
     maskStatus = PopHealth.currentUser.maskStatus()

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -2,12 +2,12 @@ class Thorax.Views.PatientView extends Thorax.View
   template: JST['patients/show']
   formattedEffectiveTime: -> formatTime @model.get('effective_time')
 
-  formattedBirthdate: -> formatTime @model.get('birthdate'), maskDate "MM/DD/YYYY"
+  formattedBirthdate: -> formatTime @model.get('birthdate'), maskDateFormat "MM/DD/YYYY"
 
   # Helper function for date/time conversion
   formatTime = (time, format) -> moment(time).format(format || 'MM/DD/YYYY') if time
 
-  maskDate = (value) -> 
+  maskDateFormat = (value) -> 
     maskStatus = PopHealth.currentUser.maskStatus()
     if value && maskStatus
       return value.replace(/[MD]/g, 'x')

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -1,9 +1,15 @@
 class Thorax.Views.PatientView extends Thorax.View
   template: JST['patients/show']
   formatted_effective_time: -> format_time @model.get('effective_time')
-  # The maskDate helper is called from this file since calling it from the patient show file 
-  # causes the format_time function to be printed to the screen instead of a proper result.
-  formatted_birthdate: -> format_time @model.get('birthdate'), Handlebars.helpers.maskDate "MM/DD/YYYY"
+
+  formatted_birthdate: -> format_time @model.get('birthdate'), maskDate "MM/DD/YYYY"
 
   # Helper function for date/time conversion
   format_time = (time, format) -> moment(time).format(format || 'MM/DD/YYYY') if time
+
+  maskDate = (value) -> 
+    maskStatus = PopHealth.currentUser.maskStatus()
+    if value && maskStatus
+      return value.replace(/[MD]/g, 'x')
+    else
+      return value

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -1,7 +1,10 @@
 class Thorax.Views.PatientView extends Thorax.View
   template: JST['patients/show']
+  name
   formatted_effective_time: -> format_time @model.get('effective_time')
-  formatted_birthdate: -> format_time @model.get('birthdate')
+  # The maskDate helper is called from this file since calling it from the patient show file 
+  # causes the format_time function to be printed to the screen instead of a proper result.
+  formatted_birthdate: -> Handlebars.helpers.maskDate format_time @model.get('birthdate')
 
   # Helper function for date/time conversion
   format_time = (time) -> moment(time).format('MM/DD/YYYY') if time

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -1,6 +1,5 @@
 class Thorax.Views.PatientView extends Thorax.View
   template: JST['patients/show']
-  name
   formatted_effective_time: -> format_time @model.get('effective_time')
   # The maskDate helper is called from this file since calling it from the patient show file 
   # causes the format_time function to be printed to the screen instead of a proper result.

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,0 +1,8 @@
+class Preference
+  include Mongoid::Document
+
+  field :selected_measure_ids, type: Array, default: []
+  field :mask_phi_data, type: Boolean, default: false
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,7 @@ class User
   field :approved, type: Boolean
   field :staff_role, type: Boolean
   field :disabled, type: Boolean
+  field :mask_phi_data, type: Boolean, default: false
   field :preferences, type: Hash, default: {selected_measure_ids: []}
 
   scope :ordered_by_username, order_by([:username, :asc])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,9 @@ class User
 
   include Mongoid::Document
 
-  before_save  :denullify_arrays
-  before_create :set_defaults, :build_preferences
+  after_initialize :build_preferences, unless: Proc.new { |user| user.preferences.present? }
+  before_save :denullify_arrays
+  before_create :set_defaults
 
   DEFAULT_EFFECTIVE_DATE = Time.gm(2011, 1, 1)
 
@@ -87,9 +88,7 @@ class User
     # if self.preferences[:selected_measure_ids] == nil
     #   binding.pry
     # end
-    unless self.preferences.nil?
-      self.preferences["selected_measure_ids"] ||= []
-    end
+    self.preferences["selected_measure_ids"] ||= []
     # puts self.preferences[:selected_measure_ids]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User
 
   include Mongoid::Document
 
-  before_create :set_defaults
-  before_save   :denullify_arrays
+  before_save  :denullify_arrays
+  before_create :set_defaults, :build_preferences
 
   DEFAULT_EFFECTIVE_DATE = Time.gm(2011, 1, 1)
 
@@ -57,12 +57,14 @@ class User
   field :approved, type: Boolean
   field :staff_role, type: Boolean
   field :disabled, type: Boolean
-  field :mask_phi_data, type: Boolean, default: false
-  field :preferences, type: Hash, default: {selected_measure_ids: []}
+
+  has_one :preferences, class_name: 'Preference'
 
   scope :ordered_by_username, order_by([:username, :asc])
 
   attr_protected :admin, :approved, :disabled, :encrypted_password, :remember_created_at, :reset_password_token, :reset_password_sent_at, :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip, :effective_date
+
+  accepts_nested_attributes_for :preferences
 
   validates_presence_of :first_name, :last_name
 
@@ -85,7 +87,9 @@ class User
     # if self.preferences[:selected_measure_ids] == nil
     #   binding.pry
     # end
-    self.preferences["selected_measure_ids"] ||= []
+    unless self.preferences.nil?
+      self.preferences["selected_measure_ids"] ||= []
+    end
     # puts self.preferences[:selected_measure_ids]
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -52,10 +52,12 @@
           <label for="tin">Tax Identifier:</label>
           <%= f.text_field :tin %>
         </li>
-        <li>
-          <label for="tin">Mask PHI Data:</label>
-          <%= f.check_box :mask_phi_data %>
-        </li>
+        <%= f.fields_for :preferences do |t| %>
+          <li>
+            <label for="tin">Mask PHI Data:</label>
+            <%= t.check_box :mask_phi_data %>
+          </li>
+        <% end %>
       </ul>
 
       <div class="actions">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -52,6 +52,10 @@
           <label for="tin">Tax Identifier:</label>
           <%= f.text_field :tin %>
         </li>
+        <li>
+          <label for="tin">Mask PHI Data:</label>
+          <%= f.check_box :mask_phi_data %>
+        </li>
       </ul>
 
       <div class="actions">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
   // PopHealth object created in application.js (specifically, within router)
   PopHealth.categories = <%= @categories.to_json.html_safe %>;
   PopHealth.patientCount = <%= @patient_count %>;
-  PopHealth.currentUser = new Thorax.Models.User(<%= current_user.to_json.html_safe %>);
+  PopHealth.currentUser = new Thorax.Models.User(<%= current_user.to_json({:include => :preferences }).html_safe %>);
   new PopHealth.Router();
   Backbone.history.start();
 </script>

--- a/spec/javascripts/fixtures/json/users.json
+++ b/spec/javascripts/fixtures/json/users.json
@@ -12,7 +12,8 @@
   "last_name": "Minn",
   "npi": "",
   "preferences": {
-    "selected_measure_ids": []
+    "selected_measure_ids": [],
+    "mask_phi_data": false
   },
   "registry_id": "",
   "registry_name": "",

--- a/spec/javascripts/models/user.spec.js.coffee
+++ b/spec/javascripts/models/user.spec.js.coffee
@@ -5,6 +5,11 @@ describe 'User', ->
     @user = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
     expect(@user.get('preferences').selected_measure_ids).toEqual []
 
+  describe 'maskStatus', ->
+    it 'returns false if the user has not enabled masking under settings', ->
+      maskStatus = @user.maskStatus()
+      expect(maskStatus).toEqual false
+
   describe 'selectedCategories', ->
     it 'returns an empty collection if there are no selected categories', ->
       selectedCategories = @user.selectedCategories(@categories)

--- a/spec/javascripts/views/patient_view.spec.js.coffee
+++ b/spec/javascripts/views/patient_view.spec.js.coffee
@@ -1,7 +1,8 @@
 describe 'PatientView', ->
   beforeEach ->
-    patients = getJSONFixture('patients.json')
-    @patient = new Thorax.Models.Patient patients[0]
+    json = loadJSONFixtures('patients.json', 'users.json')
+    window.PopHealth.currentUser = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
+    @patient = new Thorax.Models.Patient json['patients.json'][0]
     @patientView = new Thorax.Views.PatientView model: @patient
     @patientView.render()
 

--- a/spec/javascripts/views/patient_view.spec.js.coffee
+++ b/spec/javascripts/views/patient_view.spec.js.coffee
@@ -13,7 +13,7 @@ describe 'PatientView', ->
     expect(@patientView.$el).toContainText @patient.get('gender')
 
   it 'formats the effective time correctly', ->
-    expect(@patientView.formatted_effective_time()).toEqual("01/16/1970")
+    expect(@patientView.formattedEffectiveTime()).toEqual("01/16/1970")
 
   it 'formats the birthday correctly', ->
-    expect(@patientView.formatted_birthdate()).toEqual("12/21/1969")
+    expect(@patientView.formattedBirthdate()).toEqual("12/21/1969")

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -19,7 +19,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "user preferences: selected_measure_ids replaces null with empty arrays" do
-    @user.preferences = {selected_measure_ids: nil}
+    @user.preferences['selected_measure_ids'] = nil
     assert @user.save
     @user.reload
     assert_equal [], @user.preferences['selected_measure_ids']


### PR DESCRIPTION
This will hide first and last names and the date of birth if the Mask PHI Data checkbox is checked for a user.
