### PR TITLE
Fixes birthdates and ages on the patient result pages

### DIFF
--- a/app/assets/javascripts/models/patient_result.js.coffee
+++ b/app/assets/javascripts/models/patient_result.js.coffee
@@ -2,7 +2,9 @@ class Thorax.Models.PatientResult extends Thorax.Model
   parse: (attrs) ->
     # JSON that comes back is in the MongoDB M/R created format
     # We only want to work with the properties in value
-    attrs.value
+    attrs = _.extend {}, attrs.value
+    attrs.birthdate = attrs.birthdate * 1000
+    attrs
 
 class Thorax.Collections.PatientResults extends Thorax.Collection
   model: Thorax.Models.PatientResult

--- a/spec/javascripts/models/patient_results.spec.js.coffee
+++ b/spec/javascripts/models/patient_results.spec.js.coffee
@@ -1,12 +1,20 @@
 describe 'PatientResults', ->
+  beforeEach ->
+    @json = getJSONFixture 'queries/patient_results.json'
+
   describe 'Collection', ->
-    beforeEach ->
-      @json = getJSONFixture 'queries/patient_results.json'
+    beforeEach ->      
       jasmine.Ajax.useMock()
       @collection = new Thorax.Collections.PatientResults @json[0...2], parse: true, parent: jasmine.createSpyObj('parent', ['url'])
 
     it 'can fetch additional pages', ->
+      expect(@collection.length).toEqual 2
       @collection.fetchNextPage(perPage: 2)
       mostRecentAjaxRequest().response {responseText: JSON.stringify(@json[2...4]), status: 200}
-      expect(@collection.toJSON()).toEqual _(@json[0...4]).map (r) -> r.value
       expect(@collection.page).toEqual 2
+      expect(@collection.length).toEqual 4
+
+  describe 'Model', ->
+    it 'should correct birthdate to milliseconds', ->
+      pr = new Thorax.Models.PatientResult @json[0], parse: true
+      expect(pr.get('birthdate')).toEqual(259736400000)


### PR DESCRIPTION
While we were correctly handling converting birthdate from seconds
as returned by the server into milliseconds as need by the client for
dates in the Patient model, we were not doing that for the
PatientResult model. This is now properly handled.
