### PR TITLE
Improvements to the display of patient information

### DIFF
--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -12,7 +12,7 @@
 {{#collection tag='tbody' item-context=patientContext}}
   <tr>
     <td>
-      {{#link "patients/{{patient_id}}" expand-tokens=true}}{{patient_id}}{{/link}}
+      {{#link "patients/{{patient_id}}" expand-tokens=true}}{{medical_record_id}}{{/link}}
     </td>
     <td><strong>{{last}}</strong></td>
     <td>{{first}}</td>

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -26,9 +26,7 @@
     <div class="demographics">
       <dl class="dl-horizontal">
         <dt>RECORD NUMBER</dt>
-        <dd>730132778</dd>
-        <dt>EFFECTIVE DATE</dt>
-        <dd>{{effective_time}}</dd>
+        <dd>{{medical_record_number}}</dd>
         <dt>DOB</dt>
         <dd>{{birthdate}}</dd>
         <dt>GENDER</dt>

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -19,6 +19,11 @@ class Thorax.Views.PatientView extends Thorax.View
           @model.get('ethnicity').name
         else
           'None Provided'
+      languages:
+        if @model.has('languages')
+          if _.isEmpty(@model.get('languages')) then 'Not Available' else @model.get('languages')
+        else
+          'Not Available'
 
   # Helper function for date/time conversion
   formatTime = (time) -> moment(time).format('DD MMM YYYY') if time

--- a/app/assets/stylesheets/styles.css.less
+++ b/app/assets/stylesheets/styles.css.less
@@ -279,6 +279,11 @@
     .dl-horizontal {
       padding-left: 0;
       .make-md-column(6);
+      > dd {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 

--- a/spec/javascripts/views/patient_view.spec.js.coffee
+++ b/spec/javascripts/views/patient_view.spec.js.coffee
@@ -9,8 +9,16 @@ describe 'PatientView', ->
     expect(@patientView.$el).toContainText @patient.get('first')
     expect(@patientView.$el).toContainText @patient.get('last')
 
-  it 'formats the effective time correctly', ->
-    expect(@patientView.$el).toContainText "08 Oct 2013"
-
   it 'formats the birthday correctly', ->
     expect(@patientView.$el).toContainText "01 Feb 1942"
+
+  it 'renders language correctly', ->
+    expect(@patientView.$el).toContainText "eng"
+
+  it 'renders language correctly when it is not there', ->
+    clonedPatient = _.clone(@patient.toJSON())
+    clonedPatient.languages = []
+    noLanguagePatient = new Thorax.Models.Patient clonedPatient, parse: true
+    noLanguageView = new Thorax.Views.PatientView model: noLanguagePatient
+    noLanguageView.render()
+    expect(noLanguageView.$el).toContainText "Not Available"


### PR DESCRIPTION
- Now showing the medical record number in the patient and patient
  result views instead of the id generated by MongoDB
- Removed effective time from the patient view. This is a Cypress
  thing that should not be shown in popHealth. It also would not appear
  in records pulled in from Cat I
- Improvements in how language is displayed in the patient view
- Truncating id's on the patient view if they are too long
