### PR TITLE
display outliers, based on presence in the result

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -60,7 +60,7 @@ class Thorax.Models.Query extends Thorax.Model
   exceptions: -> if @isPopulated() and @has('result') then @get('result').DENEXCEP else 0
   hasExclusions: -> @has('population_ids') and @get('population_ids').hasOwnProperty('DENEX')
   exclusions: -> if @isPopulated() and @has('result') then @get('result').DENEX else 0
-  hasOutliers: -> @has('population_ids') and @get('population_ids').hasOwnProperty('antinumerator')
+  hasOutliers: -> @has('antinumerator')
   outliers: -> if @isPopulated() and @has('result') then @get('result').antinumerator else 0
   performanceDenominator: -> @denominator() - @exceptions() - @exclusions()
   performanceRate: -> Math.round(100 * @numerator() / Math.max(1, @performanceDenominator()))

--- a/app/assets/javascripts/views/measures/logic_view.js.coffee
+++ b/app/assets/javascripts/views/measures/logic_view.js.coffee
@@ -8,7 +8,7 @@ class Thorax.Views.LogicView extends Thorax.View
 
   reloadPopulation: ->
     population = @model.get @population
-    view = if population.has 'preconditions'
+    view = if population?.has 'preconditions'
       new Thorax.Views.PreconditionView model: population.get('preconditions').first()
     else
       new Thorax.Views.EmptyPopulationView population: @population

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -60,6 +60,7 @@ class Thorax.Views.QueryView extends Thorax.View
   exceptions: -> @model.exceptions()
   hasExclusions: -> @model.hasExclusions()
   exclusions: -> @model.exclusions()
+  hasOutliers: -> @model.hasOutliers()
   outliers: -> @model.outliers()
   performanceRate: -> @model.performanceRate()
   performanceDenominator: -> @model.performanceDenominator()


### PR DESCRIPTION
Previously, `hasOutliers` was looking within the population_ids for the antinumerator, though it will never be there. This code updates the result to look in the right place, as well as updates the display to display outliers correctly.
