### PR TITLE
update styles to work on lower resolution desktop machines

### DIFF
--- a/app/assets/javascripts/population_chart.js.coffee
+++ b/app/assets/javascripts/population_chart.js.coffee
@@ -7,8 +7,8 @@ PopHealth.viz.populationChart = ->
       yScale.domain(['NUMER', 'DENOM']).range [margin.top, height-margin.bottom-barHeight]
       svg = d3.select(this).selectAll('svg').data([data])
       gEnter = svg.enter().append('svg')
-        .attr('width', @width)
-        .attr('height', @height)
+        .attr('viewBox', "0 0 #{width} #{height}")
+        .attr('preserveAspectRatio', 'none')
       numer = gEnter.append('g').append('rect')
         .attr('class', 'numer')
         .attr('width', xScale(data.NUMER))
@@ -16,7 +16,7 @@ PopHealth.viz.populationChart = ->
         .attr('y', yScale('NUMER'))
         .attr('x', margin.left)
         .attr('data-placement', "top")
-        .attr('data-content', "Numerator: " + data.NUMER)
+        .attr('data-content', "Numerator: #{data.NUMER}")
         .attr('data-trigger', "hover focus")
         .attr('data-container', 'body')
 
@@ -27,9 +27,9 @@ PopHealth.viz.populationChart = ->
         .attr('width', xScale(data.performanceDenominator))
         .attr('height', barHeight)
         .attr('y', yScale('DENOM'))
-        .attr( 'x', margin.left)
+        .attr('x', margin.left)
         .attr('data-placement', "bottom")
-        .attr('data-content', "Denominator: " + data.performanceDenominator)
+        .attr('data-content', "Denominator: #{data.performanceDenominator}")
         .attr('data-trigger', "hover focus")
         .attr('data-container', 'body')
       denom.append('rect')
@@ -37,9 +37,9 @@ PopHealth.viz.populationChart = ->
         .attr('width', xScale(data.DENEX))
         .attr('height', barHeight)
         .attr('y', yScale('DENOM'))
-        .attr( 'x', xScale(data.performanceDenominator)) 
+        .attr('x', xScale(data.performanceDenominator))
         .attr('data-placement', "bottom")
-        .attr('data-content', "Exclusion: " + data.DENEX)
+        .attr('data-content', "Exclusion: #{data.DENEX}")
         .attr('data-trigger', "hover focus")
         .attr('data-container', 'body') if data.DENEX > 0
 
@@ -48,12 +48,12 @@ PopHealth.viz.populationChart = ->
         .attr('width', xScale(data.DENEXCEP))
         .attr('height', barHeight)
         .attr('y', yScale('DENOM'))
-        .attr('x', xScale(data.performanceDenominator) + xScale(data.DENEX)) 
+        .attr('x', xScale(data.performanceDenominator) + xScale(data.DENEX))
         .attr('data-placement', "bottom")
-        .attr('data-content', "Exceptions: " + data.DENEXCEP)
-        .attr('data-trigger', "hover focus") 
+        .attr('data-content', "Exceptions: #{data.DENEXCEP}")
+        .attr('data-trigger', "hover focus")
         .attr('data-container', 'body') if data.DENEXCEP > 0
-      
+
 
   width = 150
   height = 40

--- a/app/assets/javascripts/templates/patient_results/query.hbs
+++ b/app/assets/javascripts/templates/patient_results/query.hbs
@@ -9,7 +9,7 @@
 <div class="pop-chart pull-left"></div>
 
 <button class="population-btn active" id="IPP">
-  <span class="title">Initial Patient Population</span>
+  <span class="title">Initial Patient Pop.</span>
   <span class="query-result">{{ipp}}</span>
 </button>
 <button class="population-btn" id="NUMER">

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -1,51 +1,48 @@
 <div class="patient">
-  <div class="sidebar">
+  <div class="col-measure-info">
     <h1><i class="fa fa-tasks"></i> Measures</h1>
     <h2>Outliers</h2>
-    {{#button "filter" class="btn measure-btn active"}}
-      <div class="indicator">
+    {{#button "filter" class="btn btn-measure btn-primary"}}
+      <span class="indicator">
         <i class="fa fa-exclamation-triangle"></i>
-      </div>
-      <div class="measure-title">
-        Controlling High Blood Pressure
-      </div>
+      </span>
+      Controlling High Blood Pressure
     {{/button}}
-    {{#button "filter" class="btn measure-btn"}}
-      <div class="indicator">
+    {{#button "filter" class="btn btn-measure"}}
+      <span class="indicator">
         <i class="fa fa-exclamation-triangle"></i>
-      </div>
-      <div class="measure-title">
-        Smoking And Tobacco Use Cessation, Medical Assistance - Advising Smokers And Tobacco Users To Quit
-      </div>
+      </span>
+      Smoking And Tobacco Use Cessation, Medical Assistance - Advising Smokers And Tobacco Users To Quit
     {{/button}}
   </div>
 
-  <div class="main">
-    <h1 class="main-head"><i class="fa fa-user"></i> {{first}} {{last}}</h1>
-    <div id="time-bar"></div>
-    <div class="demographics">
-      <dl class="dl-horizontal">
-        <dt>RECORD NUMBER</dt>
-        <dd>{{medical_record_number}}</dd>
-        <dt>DOB</dt>
-        <dd>{{birthdate}}</dd>
-        <dt>GENDER</dt>
-        <dd>{{gender}}</dd>
-      </dl>
-      <dl class="dl-horizontal">
-        <dt>RACE</dt>
-        <dd>{{race}}</dd>
-        <dt>ETHNICITY</dt>
-        <dd>{{ethnicity}}</dd>
-        <dt>LANGUAGES</dt>
-        <dd>{{languages}}</dd>
-        <dt>PROVIDERS</dt>
-        <dd>Jonathan Cooper MD</dd>
-      </dl>
+  <div class="col-patient-info">
+    <h1 class="patient-heading"><i class="fa fa-user"></i> {{first}} {{last}}</h1>
+    <div class="timeline-entry">
+      <div class="patient-data-list">
+        <dl class="dl-horizontal">
+          <dt>RECORD NUMBER</dt>
+          <dd>{{medical_record_number}}</dd>
+          <dt>DOB</dt>
+          <dd>{{birthdate}}</dd>
+          <dt>GENDER</dt>
+          <dd>{{gender}}</dd>
+        </dl>
+        <dl class="dl-horizontal">
+          <dt>RACE</dt>
+          <dd>{{race}}</dd>
+          <dt>ETHNICITY</dt>
+          <dd>{{ethnicity}}</dd>
+          <dt>LANGUAGES</dt>
+          <dd>{{languages}}</dd>
+          <dt>PROVIDERS</dt>
+          <dd>Jonathan Cooper MD</dd>
+        </dl>
+      </div>
     </div>
-    <div class="time-line">
-      <div class="timeline-title">Patient History Relative to Measures</div>
-    </div>
+
+    <header class="timeline-entry"><h2>Patient History Relative to Measures</h2></header>
+
     {{!--
       The following section can be added back in after filtering is added and
       we have the ability to determine the cause of a patient being an outlier.
@@ -68,24 +65,23 @@
       </div>
     </div> --}}
     {{#collection entries item-view="EntryView"}}
-      <div class="record-listing">
-        <div class="circle-icon">
-          <i class="fa fa-{{icon}}"></i>
-        </div>
+      <div class="timeline-entry">
+        <div class="circle-icon"><i class="fa fa-{{icon}}"></i></div>
         <div class="patient-data">
-        <div class="triangle-left"></div>
-          <dl class="dl-record dl-horizontal">
-            <dt>{{entry_type}}</dt>
-            {{#if description}}
-              <dd>{{description}}</dd>
-            {{else}}
-              <dd class="text-muted">No Details Available</dd>
-            {{/if}}
-          </dl>
-          <dl class="dl-date dl-horizontal">
-            <dt>date</dt>
-            <dd>{{start_time}} {{#if end_time}} &ndash; {{end_time}} {{/if}}</dd>
-          </dl>
+          <div class="patient-data-list">
+            <dl class="dl-horizontal">
+              <dt>{{entry_type}}</dt>
+              {{#if description}}
+                <dd>{{description}}</dd>
+              {{else}}
+                <dd class="text-muted">No Details Available</dd>
+              {{/if}}
+            </dl>
+            <dl class="dl-horizontal">
+              <dt>date</dt>
+              <dd>{{start_time}}{{#if end_time}} &ndash; {{end_time}}{{/if}}</dd>
+            </dl>
+          </div>
         </div>
       </div>
     {{/collection}}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,7 +1,0 @@
-/*
- * This is a manifest file that'll automatically include all the stylesheets available in this directory
- * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
- * the top of the compiled file, but it's generally better to create a new file per style scope.
- *= require_self
- *= require styles
-*/

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -1,0 +1,13 @@
+// Import external dependencies
+@import "bootstrap/less/bootstrap";
+@import "font-awesome/less/font-awesome";
+
+// Helper files
+@import "bootstrap3";
+// @import "variables";
+// @import "mixins";
+
+// Styles by page
+@import "login";
+@import "patient";
+@import "styles";

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -1,4 +1,5 @@
-@import "bootstrap/less/bootstrap";
+@icon-font-path: "../fonts/";
+@fa-font-path: "../fonts";
 
 // Bootstrap Variables
 
@@ -95,6 +96,12 @@ h4 {
 }
 
 // Additions to Bootstrap classes
+
+.dl-horizontal {
+  dt{
+    text-transform: uppercase;
+  }
+}
 
 .text-muted {
   font-style: italic;

--- a/app/assets/stylesheets/patient.less
+++ b/app/assets/stylesheets/patient.less
@@ -1,0 +1,92 @@
+.patient {
+  .make-row;
+  .col-measure-info {
+    .make-md-column(3);
+  }
+
+  .col-patient-info {
+    .make-md-column(9);
+    .patient-heading {
+      margin-left: -10px;
+    }
+    // h2 {
+    //   background-color: @gray;
+    // }
+    .timeline-entry {
+      border-left: 8px solid @gray-lighter;
+      padding: 10px 0 0 @grid-gutter-width;
+      &.during-measurement-period {
+        border-left: 8px solid @brand-primary;
+      }
+    }
+    header.timeline-entry {
+      background-color: @gray-lighter;
+      padding: 8px 0 8px @grid-gutter-width;
+      h2 {
+        margin: 0;
+      }
+    }
+  }
+
+  .btn-measure {
+    display: block;
+    text-align: left;
+    white-space: normal;
+    width: 100%;
+    & + .btn-measure {
+      margin-top: 5px;
+    }
+  }
+
+
+  .circle-icon {
+    @radius: 18px;
+    position: absolute;
+    left: 0px;
+    background-color: white;
+    border: 2px solid @brand-primary;
+    border-radius: @radius;
+    color: @brand-primary;
+    .square(@radius * 2);
+    line-height: 2;
+    text-align: center;
+    &.selected {
+      background-color: @brand-primary;
+      color: white;
+    }
+  }
+
+  .patient-data {
+    position: relative;
+    border: 1px solid @gray;
+    &:before {
+      content: ' ';
+      background-color: white;
+      border-bottom: 1px solid @gray;
+      border-left: 1px solid @gray;
+      position: absolute;
+      .square(@grid-gutter-width / 2);
+      left: -(@grid-gutter-width / 4) - 1; // width/2 (-1 to account for border)
+      top: 9px;
+      .rotate(45deg);
+    }
+    &.selected {
+      @border-selected: 2px dashed white;
+      background-color: @brand-primary;
+      border: @border-selected;
+      color: white;
+      &:before {
+        background-color: @brand-primary;
+        border-bottom: @border-selected;
+        border-left: @border-selected;
+      }
+    }
+  }
+
+  .patient-data-list {
+    .make-row;
+    dl {
+      .make-md-column(6);
+    }
+  }
+}

--- a/app/assets/stylesheets/styles.less
+++ b/app/assets/stylesheets/styles.less
@@ -1,25 +1,8 @@
-@import "bootstrap3";
-@import "font-awesome/less/font-awesome";
 
-@icon-font-path: "../fonts/";
-@fa-font-path: "../fonts";
-
-// Custom Variables
-@title-line-height: 1.5;
-@title-bar-height: 3em;
-@listing-line-height: 1.5;
 @circle-bkg-color: #fff;
 @title-circle-radius: 21px;
 
 // Custom styles that are part of the theme
-
-.dl-horizontal {
-  dt{
-    text-transform: uppercase;
-    text-align: left;
-  }
-}
-
 
 .fraction-listing {
   text-align: center;
@@ -101,16 +84,23 @@
 .pop-chart {
   height: 50px;
   width: 125px;
-  rect{
-    stroke:white;
-    stroke-width:0px;
-    fill: rgb(205,205,205);
+  // shrink this down on smaller displays
+  @media (max-width: @screen-md-max) {
+    width: 80px;
   }
-  .numer {
-    fill: rgb(59,133,140);
-  }
-  .denom {
-    fill: rgb(59,133,140);
+  svg {
+    .size(100%; 100%);
+    rect {
+      stroke:white;
+      stroke-width:0px;
+      fill: rgb(205,205,205);
+    }
+    .numer {
+      fill: rgb(59,133,140);
+    }
+    .denom {
+      fill: rgb(59,133,140);
+    }
   }
 }
 
@@ -227,166 +217,3 @@
     }
   }
 }
-
-// patient view
-.patient {
-  .row;
-  .sidebar {
-    .measure-btn {
-      width: 260px;
-      background-color: @gray-lighter;
-      margin-bottom: 5px;
-      padding: 10px 15px;
-      border-bottom: 1px solid transparent;
-      white-space: normal;
-      text-align: left;
-      > * {
-        display: inline;
-      }
-      &.active {
-        background-color: @brand-primary;
-        color: #fff;
-      }
-    }
-    .indicator {
-      width: 14px;
-      padding-right: 5px;
-    }
-  }
-
-  .main-head {
-    font-size: 36px;
-    .fa-user {
-      .make-md-column(1);
-      text-align: left;
-      padding-left: 3px;
-    }
-  }
-
-  #time-bar {
-    position: absolute;
-    left: 28px;
-    top: 54px;
-    width: 8px;
-    height: 100%;
-    background-color: @gray-lighter;
-  }
-
-  .demographics {
-    .clearfix;
-    .make-sm-column-offset(1);
-
-    .dl-horizontal {
-      padding-left: 0;
-      .make-md-column(6);
-      > dd {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    }
-  }
-
-  .time-line {
-    background-color: @gray-lighter;
-    margin-left: 15px;
-
-    .timeline-title {
-      .make-md-column-offset(1);
-      font-size: 24px;
-      font-weight: bold;
-      text-transform: uppercase;
-    }
-  }
-
-  .record-listing {
-    .make-md-column(12);
-    padding: 15px 0;
-    margin-top: 20px;
-
-    .active {
-      background-color: @brand-primary;
-      color: #fff;
-      border: 2px dashed #fff;
-    }
-
-    .circle-icon {
-      .pull-left;
-      .make-md-column(1);
-      margin-top: 8px;
-      padding-left: 0;
-
-      .fa {
-        text-align: center;
-        padding-top: 7px;
-        width: 36px;
-        height: 36px;
-        background-color: white;
-        border-radius: 18px;
-        border: 2px solid @brand-primary;
-        color: @brand-primary;
-        font-size: 18px;
-        margin: auto;
-      }
-
-      .active-icon {
-        .fa {
-          background-color: @brand-primary;
-          border-radius: 18px;
-          color: white;
-        }
-      }
-    }
-
-    .patient-data {
-      .make-md-column(11);
-      background-color: white;
-      border: 1px solid @gray-darker;
-
-      &:before {
-         content:"";
-         position: absolute;
-         right: 100%;
-         top: 11px;
-         width: 0;
-         height: 0;
-         border-top: 14px solid transparent;
-         border-right: 20px solid black;
-         border-bottom: 14px solid transparent;
-      }
-
-      &:after {
-         content:"";
-         position: absolute;
-         right: 100%;
-         top: 12px;
-         width: 0;
-         height: 0;
-         border-top: 13px solid transparent;
-         border-right: 19px solid white;
-         border-bottom: 13px solid transparent;
-      }
-
-      dl {
-        margin-bottom: 15px;
-        line-height: 24px;
-      }
-
-      .dl-record {
-        .make-md-column(8);
-      }
-
-      .dl-date {
-        .make-md-column(4);
-        padding-right: 0;
-        dt {
-          width: 60px;
-        }
-        dd {
-          margin-left: 0px;
-        }
-      }
-    }
-  }
-}
-@import "login.less";


### PR DESCRIPTION
Design changes to accommodate smaller desktops (between 992px and 1199px wide), and in some cases, even smaller devices.
- Use smaller width for bar graphs on dashboard when viewed on small desktop
- Use "Initial Patient Pop." instead of "Initial Patient Population" on measure listing/patients listing
- Almost complete redesign of Patient page to be more responsive/more manageable

Some stylesheet organization is also done as part of this PR.
