### PR TITLE
update patient results view spec to mock AJAX request

### DIFF
--- a/spec/javascripts/vendor/mock-ajax.js
+++ b/spec/javascripts/vendor/mock-ajax.js
@@ -55,8 +55,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       this.requests.reset();
     };
 
-    this.stubRequest = function(url) {
-      var stub = new RequestStub(url);
+    this.stubRequest = function(url, data) {
+      var stub = new RequestStub(url, data);
       stubTracker.addStub(stub);
       return stub;
     };
@@ -85,10 +85,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       stubs = [];
     };
 
-    this.findStub = function(url) {
+    this.findStub = function(url, data) {
       for (var i = stubs.length - 1; i >= 0; i--) {
         var stub = stubs[i];
-        if (stub.url === url) {
+        if (stub.matches(url, data)) {
           return stub;
         }
       }
@@ -109,6 +109,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         this.username = arguments[3];
         this.password = arguments[4];
         this.readyState = 1;
+        this.onreadystatechange();
       },
 
       setRequestHeader: function(header, value) {
@@ -119,6 +120,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         this.readyState = 0;
         this.status = 0;
         this.statusText = "abort";
+        this.onreadystatechange();
       },
 
       readyState: 0,
@@ -134,8 +136,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       send: function(data) {
         this.params = data;
         this.readyState = 2;
+        this.onreadystatechange();
 
-        var stub = stubTracker.findStub(this.url);
+        var stub = stubTracker.findStub(this.url, data);
         if (stub) {
           this.response(stub);
         }
@@ -243,14 +246,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
   }
 
-  function RequestStub(url) {
+  function RequestStub(url, stubData) {
     this.url = url;
+    this.data = stubData ? stubData.split('&').sort().join('&') : undefined;
 
     this.andReturn = function(options) {
       this.status = options.status || 200;
 
       this.contentType = options.contentType;
       this.responseText = options.responseText;
+    };
+
+    this.matches = function(url, data) {
+      return this.url === url && (!this.data || this.data === (data && data.split('&').sort().join('&')));
     };
   }
 

--- a/spec/javascripts/views/patient_results_view.spec.js.coffee
+++ b/spec/javascripts/views/patient_results_view.spec.js.coffee
@@ -1,10 +1,14 @@
 describe 'PatientResultsView', ->
   beforeEach ->
-    queryJSON = getJSONFixture('query.json')
-    query = new Thorax.Models.Query queryJSON, parse: true
-    @patientResultsView = new Thorax.Views.PatientResultsView query: query 
-    @patientResultsView.render()
+    json = loadJSONFixtures 'query.json', 'queries/patient_results.json', 'users.json'
+    window.PopHealth.currentUser = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
+    jasmine.Ajax.install()
+    query = new Thorax.Models.Query json['query.json'], parse: true
+    @patientResultsView = new Thorax.Views.PatientResultsView query: query
+    jasmine.Ajax.requests.mostRecent().response responseText: JSON.stringify(json['queries/patient_results.json'][2...4]), status: 200
+
+  afterEach ->
+    jasmine.Ajax.uninstall()
 
   it 'renders the patient list', ->
-    @patientResultsView.collection.each (r) =>
-      expect(@patientResultsView.$el).toContainText r.get('last')
+    expect(@patientResultsView.$el).toContainText @patientResultsView.collection.first().get('last')


### PR DESCRIPTION
The patient results view was passing erroneously as the results collection is empty until it becomes populated via AJAX. As there's no server running, we need to mock the AJAX request/response.

This also includes an upgrade of the mock-ajax library.
