### PR TITLE
Removing individual patient update to CQM results

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,18 +15,18 @@ class AdminController < ApplicationController
   end
 
   def remove_patients
-    Record.all.delete
+    Record.delete_all
     redirect_to action: 'patients'
   end
 
   def remove_caches
-    QueryCache.all.delete
-    PatientCache.all.delete
+    QueryCache.delete_all
+    PatientCache.delete_all
     redirect_to action: 'patients'
   end
 
   def remove_providers
-    Provider.destroy_all
+    Provider.delete_all
     redirect_to action: 'patients'
   end
   

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -8,9 +8,10 @@ class RecordsController < ActionController::Metal
 
       if (result[:status] == 'success') 
         @record = result[:record]
-        QME::QualityReport.update_patient_results(@record.medical_record_number)
         Atna.log(current_user.username, :phi_import)
         Log.create(:username => current_user.username, :event => 'patient record imported', :medical_record_number => @record.medical_record_number)
+        QueryCache.delete_all
+        PatientCache.delete_all
       end
 
       self.content_type = "text/plain"


### PR DESCRIPTION
Previously, when a new record was uploaded, we would try to update
all calculation results for just that patient. This code now updates
the record and wipes out all caches. It appears that most popHealth
users upload records in bulk, so individual updates don't make much
sense.

Additionally, some places where collections are cleared, the method
for doing that has been switched from all.delete to delete_all.
