### PR TITLE
show a count of selected measures for each category on dashboard

### DIFF
--- a/app/assets/javascripts/templates/dashboard/index.hbs
+++ b/app/assets/javascripts/templates/dashboard/index.hbs
@@ -5,10 +5,13 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <h4 class="panel-title">
+            <div class="selection-pull-out">
+              <span class="measure-count">{{measure_count}}</span>
+              <i class="glyphicon glyphicon-chevron-right"></i>
+            </div>
             <a class="accordion-toggle" data-toggle="collapse" data-parent="#measureSelectors" href="#category{{@cid}}">
               {{category}}
             </a>
-            <i class="glyphicon glyphicon-chevron-right pull-right"></i>
           </div>
         </div>
         <div id="category{{@cid}}" class="panel-collapse collapse">

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -125,28 +125,6 @@ h4 {
   border: 1px #CCCCCC solid;
 }
 
-.panel {
-  width: 100%;
-  box-shadow: none;
-  .panel-title {
-    font-weight: 500;
-    .row;
-    margin: 0;
-    a {
-      .make-xs-column(10);
-      padding: 0;
-    }
-    i {
-      .make-xs-column(2);
-      padding: 0;
-      width: 16px !important;
-    }
-  }
-  .panel-body {
-    padding: 5px;
-  }
-}
-
 .popover {
   box-shadow: none;
   .popover-content {  // inheriting font-weight from measure-title for some reason...

--- a/app/assets/stylesheets/styles.less
+++ b/app/assets/stylesheets/styles.less
@@ -66,6 +66,17 @@
   }
 }
 
+.selection-pull-out {
+  .pull-right;
+  margin: 0 0 3px 3px;
+  .measure-count {
+    .badge;
+  }
+  i {
+    vertical-align: top;
+  }
+}
+
 .measure {
   margin-top: 1em;
   .measure-title {


### PR DESCRIPTION
This displays the number of selected measures for each category next to the category name.

A downside of this implementation is that it's pretty closely linked with the DOM. An alternate implementation might involve a separate explicit view for each category, with a listener that listens to changes in the size of the collection, and updates the view accordingly. This'd probably require a bit of a rewrite of how the selected category model code works, and would require a new view, and just seemed like more work than this feature deserves. If the structure of the dashboard ends up changing significantly, though, this might be an approach we might want to consider.
