### PR TITLE
Allow popHealth to run when not in a git repository

### DIFF
--- a/config/initializers/version_from_git.rb
+++ b/config/initializers/version_from_git.rb
@@ -1,5 +1,12 @@
-#This pulls the commit hash first-6 and most recent tag from git
-g = Git.open(".")
+begin
+  #This pulls the commit hash first-6 and most recent tag from git
+  g = Git.open(".")
 
-PopHealth::Application.config.commit = g.log.first.objectish.slice(0,6)
-PopHealth::Application.config.tag = g.tags.last.name
+  PopHealth::Application.config.commit = g.log.first.objectish.slice(0,6)
+  last_tag = g.tags.last
+  PopHealth::Application.config.tag = last_tag ? last_tag.name : "Unknown"
+rescue ArgumentError => e
+  #Path does not exist
+  PopHealth::Application.config.commit = "Unknown"
+  PopHealth::Application.config.tag = "Unknown"
+end


### PR DESCRIPTION
popHealth has code that will check the .git directory for information
about the latest commit and tag. This change will now display
"Unknown" when there is no .git directory. It should also handle the
situation where tags may not be present (this seems to be the case
when testing on Travis CI).
