### PR TITLE
add dashboard to provider view

### DIFF
--- a/app/assets/javascripts/templates/dashboard/index.hbs
+++ b/app/assets/javascripts/templates/dashboard/index.hbs
@@ -67,7 +67,7 @@
               <a href="#measures/{{id}}/{{sub_id}}">{{short_subtitle}}</a>
             {{/if}}
           </div>
-          {{view "ResultsView" model=query id=id sub_id=sub_id}}
+          {{view "ResultsView" model=query id=id sub_id=sub_id provider_id=../../../provider_id}}
         </div>
       {{/collection}}
     {{/collection}}

--- a/app/assets/javascripts/templates/providers/show.hbs
+++ b/app/assets/javascripts/templates/providers/show.hbs
@@ -14,3 +14,5 @@
   <dt>Team:</dt>
   <dd>{{team.name}}</dd>
 </dl>
+
+<div class="row">{{view dashboardView}}</div>

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -19,6 +19,7 @@ class Thorax.Views.ResultsView extends Thorax.View
   denominator: -> @model.denominator()
   performanceDenominator: -> @model.performanceDenominator()
   initialize: ->
+    @model.set('provider_id', @provider_id) if @provider_id?
     @popChart = PopHealth.viz.populationChart().width(125).height(50).barHeight(18).maximumValue(PopHealth.patientCount)
     unless @model.isPopulated()
       @timeout = setInterval =>

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -1,5 +1,7 @@
 class Thorax.Views.ProviderView extends Thorax.View
   template: JST['providers/show']
+  initialize: ->
+    @dashboardView = new Thorax.Views.Dashboard provider_id: @model.id, collection: new Thorax.Collections.Categories PopHealth.categories, parse: true
 
 class Thorax.Views.ProvidersView extends Thorax.View
   tagName: 'table'


### PR DESCRIPTION
This attaches the dashboard view to the provider view, and instantiates it with a provider ID. Any queries within this provider-centric dashboard view will pass a `provider_id` to the server.
