### PR TITLE
standardize on :providers array for supplying provider ids to queries

### DIFF
--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -19,7 +19,7 @@ class Thorax.Views.ResultsView extends Thorax.View
   denominator: -> @model.denominator()
   performanceDenominator: -> @model.performanceDenominator()
   initialize: ->
-    @model.set('provider_id', @provider_id) if @provider_id?
+    @model.set('providers', [@provider_id]) if @provider_id?
     @popChart = PopHealth.viz.populationChart().width(125).height(50).barHeight(18).maximumValue(PopHealth.patientCount)
     unless @model.isPopulated()
       @timeout = setInterval =>

--- a/app/controllers/api/queries_controller.rb
+++ b/app/controllers/api/queries_controller.rb
@@ -37,6 +37,7 @@ module Api
     param :sub_id, String, :desc => 'The sub id for the CQM to calculate. This is popHealth specific.', :required => false
     param :effective_date, ->(effective_date){ effective_date.present? }, :desc => 'Time in seconds since the epoch for the end date of the reporting period',
                                    :required => true
+    param :providers, Array, :desc => 'An array of provider IDs to filter the query by'
     example '{"_id":"52fe409bb99cc8f818000001", "status":{"state":"queued", ...}, ...}'
     description <<-CDESC
       This action will create a clinical quality measure calculation. If the measure has already been calculated,
@@ -45,7 +46,6 @@ module Api
       GET action with the id.
     CDESC
     def create
-      # binding.pry
       build_filter
       authorize_providers
       qr = QME::QualityReport.find_or_create(params[:measure_id],

--- a/app/controllers/api/queries_controller.rb
+++ b/app/controllers/api/queries_controller.rb
@@ -4,7 +4,7 @@ module Api
       short 'Queries'
       formats ['json']
       description <<-QCDESC
-        This resource is responsible for managing clinical quality measure calculations. Creating a new query will kick 
+        This resource is responsible for managing clinical quality measure calculations. Creating a new query will kick
         off a new CQM caluclation (if it hasn't already been calculated). You can determine the status of ongoing
         calculations, force recalculations and see results through this resource.
       QCDESC
@@ -13,7 +13,7 @@ module Api
     skip_authorization_check :only=> :create
     before_filter :authenticate_user!
     before_filter :set_pagination_params, :only=>[:patient_results, :patients]
-   
+
     def index
       filter = {}
       filter["hqmf_id"] = {"$in" => params["measure_ids"]} if params["measure_ids"]
@@ -35,16 +35,17 @@ module Api
     api :POST, '/queries', "Start a clinical quality measure calculation"
     param :measure_id, String, :desc => 'The HQMF id for the CQM to calculate', :required => true
     param :sub_id, String, :desc => 'The sub id for the CQM to calculate. This is popHealth specific.', :required => false
-    param :effective_date, ->(effective_date){ effective_date.present? }, :desc => 'Time in seconds since the epoch for the end date of the reporting period', 
+    param :effective_date, ->(effective_date){ effective_date.present? }, :desc => 'Time in seconds since the epoch for the end date of the reporting period',
                                    :required => true
     example '{"_id":"52fe409bb99cc8f818000001", "status":{"state":"queued", ...}, ...}'
     description <<-CDESC
       This action will create a clinical quality measure calculation. If the measure has already been calculated,
       it will return the results. If not, it will return the status of the calculation, which can be checked in
       the status property of the returned JSON. If it is calculating, then the results may be obtained by the
-      GET action with the id. 
+      GET action with the id.
     CDESC
     def create
+      # binding.pry
       build_filter
       authorize_providers
       qr = QME::QualityReport.find_or_create(params[:measure_id],
@@ -76,7 +77,7 @@ module Api
       render json: qr
     end
 
-    api :GET, '/queries/:id/patient_results[?population=true|false]', 
+    api :GET, '/queries/:id/patient_results[?population=true|false]',
               "Retrieve patients relevant to a clinical quality measure calculation"
     param :id, String, :desc => 'The id of the quality measure calculation', :required => true
     param :ipp, /true|false/, :desc => 'Ensure patients meet the initial patient population for the measure', :required => false
@@ -96,7 +97,7 @@ module Api
     def patient_results
       qr = QME::QualityReport.find(params[:id])
       authorize! :read, qr
-      # this returns a criteria object so we can filter it additionally as needed 
+      # this returns a criteria object so we can filter it additionally as needed
       results = qr.patient_results
       render json: paginate(patient_results_api_query_url(qr),results.where(build_patient_filter).order_by([:last.asc, :first.asc]))
     end
@@ -104,7 +105,7 @@ module Api
     def patients
       qr = QME::QualityReport.find(params[:id])
       authorize! :read, qr
-      # this returns a criteria object so we can filter it additionally as needed 
+      # this returns a criteria object so we can filter it additionally as needed
       results = qr.patient_results
       ids = paginate(patients_api_query_url(qr),results.where(build_patient_filter).order_by([:last.asc, :first.asc])).collect{|r| r["value.medical_record_id"]}
       render :json=> Record.where({:medical_record_number.in => ids})
@@ -113,7 +114,7 @@ module Api
 
   private
     def build_filter
-      @filter = params[:filter] || {}
+      @filter = params.select { |k, v| %w(providers).include? k }.to_options
     end
 
     def authorize_providers
@@ -124,7 +125,7 @@ module Api
           authorize! :read, provider
         end
       else
-        #this is hacky and ugly but cancan will allow just the 
+        #this is hacky and ugly but cancan will allow just the
         # class Provider to pass for a simple user so providing
         #an empty Provider with no NPI number gets around this
         authorize! :read, Provider.new

--- a/test/functional/api/queries_controller_test.rb
+++ b/test/functional/api/queries_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 include Devise::TestHelpers
 module Api
   class QueriesControllerTest < ActionController::TestCase
-    
+
     setup do
       dump_database
       collection_fixtures 'measures'
@@ -42,98 +42,98 @@ module Api
 
 
 
-    test "show admin" do 
+    test "show admin" do
       sign_in @admin
       get :show, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
-    
-    test "show npi" do 
+
+    test "show npi" do
       sign_in @npi_user
       get :show, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    test "show unauthorized" do 
+    test "show unauthorized" do
       sign_in @user
       get :show, :id=>"523c57e2949d9dd06956b606"
       assert_response 403
     end
 
-    test "show staff_role" do 
+    test "show staff_role" do
       sign_in @staff
       get :show, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    test "delete admin" do 
+    test "delete admin" do
       sign_in @admin
       delete :destroy, :id=>"523c57e2949d9dd06956b606"
       assert_response 204
     end
-    
-    test "delete npi" do 
+
+    test "delete npi" do
       sign_in @npi_user
       delete :destroy, :id=>"523c57e2949d9dd06956b606"
       assert_response 204
     end
 
-    test "delete unauthorized" do 
+    test "delete unauthorized" do
       sign_in @user
       delete :destroy, :id=>"523c57e2949d9dd06956b606"
       assert_response 403
     end
 
-    test "delete staff_role" do 
+    test "delete staff_role" do
       sign_in @staff
       delete :destroy, :id=>"523c57e2949d9dd06956b606"
       assert_response 204
     end
 
 
-    test "recalculate admin" do 
+    test "recalculate admin" do
       sign_in @admin
       get :recalculate, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
-    
-    test "recalculate npi" do 
+
+    test "recalculate npi" do
       sign_in @npi_user
       get :recalculate, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    test "recalculate unauthorized" do 
+    test "recalculate unauthorized" do
       sign_in @user
       get :recalculate, :id=>"523c57e2949d9dd06956b606"
       assert_response 403
     end
 
-    test "recalculate staff_role" do 
+    test "recalculate staff_role" do
       sign_in @staff
       get :recalculate, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    test "patient_results admin" do 
+    test "patient_results admin" do
       sign_in @admin
       get :patient_results, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
-    
-    test "patient_results npi" do 
+
+    test "patient_results npi" do
       sign_in @npi_user
       get :patient_results, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    test "patient_results unauthorized" do 
+    test "patient_results unauthorized" do
       sign_in @user
       get :patient_results, :id=>"523c57e2949d9dd06956b606"
       assert_response 403
     end
 
-    test "patient_results staff_role" do 
+    test "patient_results staff_role" do
       sign_in @staff
       get :patient_results, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
@@ -141,34 +141,34 @@ module Api
 
 
 
-    test "patients admin" do 
+    test "patients admin" do
       sign_in @admin
       get :patients, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
-    
-    test "patients npi" do 
+
+    test "patients npi" do
       sign_in @npi_user
       get :patients, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    test "patients unauthorized" do 
+    test "patients unauthorized" do
       sign_in @user
       get :patients, :id=>"523c57e2949d9dd06956b606"
       assert_response 403
     end
 
-    test "patients staff_role" do 
+    test "patients staff_role" do
       sign_in @staff
       get :patients, :id=>"523c57e2949d9dd06956b606"
       assert_response :success
     end
 
-    
+
     test "create admin" do
       sign_in @admin
-      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :filter=>{:providers=>[@provider.id]}
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response :success, "admin should be able to create reports for npis "
 
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
@@ -177,16 +177,16 @@ module Api
 
     test "create staff" do
       sign_in @staff
-      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212,:filter=>{:providers=>[@provider.id]}
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response :success, "staff should be able to create all reports for npis"
 
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
       assert_response :success, "staff should be able to create all reports for no npi"
-    end 
+    end
 
     test "create npi user" do
       sign_in @npi_user
-      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE',  :sub_id=>"a",:effective_date=>1212121212, :filter=>{:providers=>[@provider.id]}
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response :success, "should be able to create a quality report for users own npi"
 
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
@@ -195,13 +195,13 @@ module Api
 
     test "create unauthorized" do
       sign_in @user
-      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE',  :sub_id=>"a",:effective_date=>1212121212,:filter=>{:providers=>[@provider.id]}
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response 403, "Should be unauthorized for npi"
 
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
       assert_response 403, "Should be unauthorized with no npi"
 
-    end 
+    end
 
 
     test "filter patient results" do
@@ -223,9 +223,9 @@ module Api
 
     end
 
-    test "index admin" do 
+    test "index admin" do
       skip "need to implement"
     end
-    
+
   end
 end


### PR DESCRIPTION
This creates a standard for using filters by adding them as top-level parameters, then selected individually via `build_filter`. It also modifies the client to use 'providers' with an array of IDs instead of passing a single 'provider_id'.
