### PR TITLE
Provider Page Links on Name not NPI

### DIFF
--- a/app/assets/javascripts/templates/providers/index.hbs
+++ b/app/assets/javascripts/templates/providers/index.hbs
@@ -1,8 +1,7 @@
 <thead>
   <tr>
     <th class="pid">Provider NPI</th>
-    <th>Last Name</th>
-    <th>First Name</th>
+    <th>Provider Name</th>
     <th>Tax ID</th>
     <th>Phone</th>
     <th>Team</th>
@@ -11,10 +10,9 @@
 {{#collection tag='tbody'}}
   <tr>
     <td>
-      {{#link "providers/{{_id}}" expand-tokens=true}}{{npi}}{{/link}}
+      {{npi}}
     </td>
-    <td><strong>{{family_name}}</strong></td>
-    <td>{{given_name}}</td>
+    <td>{{#link "providers/{{_id}}" expand-tokens=true}}{{given_name}}{{/link}}</td>
     <td>{{tin}}</td>
     <td>{{phone}}</td>
     <td>{{team.name}}</td>


### PR DESCRIPTION
Changes to the Provider screen to move link from NPI onto name. And also remove the assumption that a provider is a person.
