### PR TITLE
Input box height is wrong when the registration page contains an error.

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -10,5 +10,6 @@
 // Styles by page
 @import "login";
 @import "patient";
+@import "register";
 @import "styles";
 @import "vis";

--- a/app/assets/stylesheets/register.less
+++ b/app/assets/stylesheets/register.less
@@ -1,0 +1,9 @@
+// When a field has a validation error, rails generates the field wrapped in a fields_with_errors class.
+// This causes the height to be correct of elements wrapped in .field_with_errors on the registration page.
+.input-group-lg {
+  .field_with_errors {
+    .form-control {
+      height: 45px;
+    }
+  }
+}

--- a/app/assets/stylesheets/register.less
+++ b/app/assets/stylesheets/register.less
@@ -4,6 +4,7 @@
   .field_with_errors {
     .form-control {
       height: 45px;
+      font-size: 18px;
     }
   }
 }


### PR DESCRIPTION
If a user hits register and has an error with their submission, any of the elements wrapped by field_with_errors end up being the wrong height.
