### PR TITLE
Category 3 generation api (per request)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rails', '3.2.14'
-gem 'quality-measure-engine', '3.0.0'
+gem 'quality-measure-engine', '3.0.1'
 
 gem 'health-data-standards', '3.4.4'
 gem 'nokogiri'

--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -53,12 +53,12 @@
     description "Upload a QRDA Category I document for a patient into popHealth."
     def create
       authorize! :create, Record
-      RecordImporter.import(params[:file])
+      HealthDataStandards::Import::BulkRecordImporter.import(params[:file])
     end
 
     def load
       authorize! :create, Record
-      RecordImporter.load_zip(params[:file])
+      HealthDataStandards::Import::BulkRecordImporter.import_archive(params[:file])
     end
 
     def toggle_excluded

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -63,7 +63,7 @@ module Api
       test_id = Moped::BSON::ObjectId.new
 
       # Import records
-      Zip::ZipFile.open(file.path) do |zipfile|
+      Zip::ZipFile.open(temp_file.path) do |zipfile|
         zipfile.entries.each do |entry|
           next if entry.directory?
           xml = zipfile.read(entry.name)
@@ -73,14 +73,17 @@ module Api
               assert result[:message]
             end
           rescue Exception => e
-            failed_dir = File.join(file.dirname, 'failed_imports')
+            failed_dir = File.join(temp_file.dirname, 'failed_imports')
             unless(Dir.exists?(failed_dir))
               Dir.mkdir(failed_dir)
             end
-            FileUtils.cp(file, failed_dir)
+            FileUtils.cp(temp_file, failed_dir)
           end
         end
       end
+
+      # Delete temp zip
+      File.delete(temp_file.path)
 
       # Initialize parameters
       generation_params = JSON.parse(params[:generation_params])

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -9,6 +9,7 @@ module Api
         quality measure calculations.
       RCDESC
     end
+
     before_filter :authenticate_user!
     skip_authorization_check
 
@@ -23,7 +24,7 @@ module Api
     CDESC
     def cat3
       measure_ids = params[:measure_ids] ||current_user.preferences["selected_measure_ids"]
-      filter = measure_ids=="all" ? {}  : {:hqmf_id.in =>measure_ids}
+      filter = measure_ids=="all" ? {}  : {:hqmf_id.in =>measure_ids.map { |mId| mId.upcase }}
       exporter =  HealthDataStandards::Export::Cat3.new
       effective_date = params["effective_date"] || current_user.effective_date || Time.gm(2012, 12, 31)
       end_date = Time.at(effective_date.to_i)
@@ -38,6 +39,79 @@ module Api
                                    effective_date.to_i,
                                    end_date.years_ago(1),
                                    end_date, provider_filter), content_type: "attachment/xml"
+    end
+
+    api :POST, '/reports/qrda_cat3_inplace', "Retrieve a QRDA Category III document calculated from passed in QRDA Category I patient files"
+    param :generation_params, String, :desc => 'JSON object specifying start_date (since epoch in seconds), effective_date (since epoch in seconds) and measure_ids (the HQMF ID of the measures to include in the document)', :required => false
+    param :cat1_zip, :desc => 'Zip archive of patient QRDA Category 1 files for measures requested', :required => true
+    description <<-CDESC
+      This action will generate a QRDA Category III document calculated over passed in QRDA Category I patient files. If measure_ids and effective_date are not provided,
+      the values from the user's dashboard will be used.
+    CDESC
+    def cat3_inplace
+
+      file = params[:cat1_zip]
+
+      # Save zip to temp location
+      FileUtils.mkdir_p(File.join(Dir.pwd, "tmp/import"))
+      file_location = File.join(Dir.pwd, "tmp/import")
+      file_name = "patient_upload" + Time.now.to_i.to_s + rand(1000).to_s
+      temp_file = File.new(file_location + "/" + file_name, "w")
+      File.open(temp_file.path, "wb") { |f| f.write(file.read) }
+
+      # Generate unique id used for the calculation
+      test_id = Moped::BSON::ObjectId.new
+
+      # Import records
+      Zip::ZipFile.open(file.path) do |zipfile|
+        zipfile.entries.each do |entry|
+          next if entry.directory?
+          xml = zipfile.read(entry.name)
+          begin
+            result = HealthDataStandards::Import::BulkRecordImporter.import(xml)
+            if (result[:status] == 'success')
+              # Mark records with test id
+              record = result[:record]
+              record.test_id = test_id
+              record.save
+            else
+              assert result[:message]
+            end
+          rescue Exception => e
+            failed_dir = File.join(file.dirname, 'failed_imports')
+            unless(Dir.exists?(failed_dir))
+              Dir.mkdir(failed_dir)
+            end
+            FileUtils.cp(file, failed_dir)
+          end
+        end
+      end
+
+      # Initialize parameters
+      generation_params = JSON.parse(params[:generation_params])
+      measure_ids = generation_params['measure_ids'] || current_user.preferences["selected_measure_ids"]
+      effective_date = generation_params['end_date'] || current_user.effective_date || Time.gm(2012, 12, 31)
+      end_date = Time.at(effective_date.to_i)
+      start_date = Time.at(generation_params['start_date'] || (end_date.years_ago(1) + 1.day))
+
+      # Initialize filters
+      measures_filter = measure_ids=="all" ? {}  : {:hqmf_id.in =>measure_ids.map { |mId| mId.upcase }} #Measure Ids are stored in uppercase
+
+      # Ensure every measure is calculated
+      HealthDataStandards::CQM::Measure.where(measures_filter).each do |measure|
+        oid_dictionary = OidHelper.generate_oid_dictionary(measure)
+        qr = QME::QualityReport.find_or_create(measure.hqmf_id, measure.sub_id, {'effective_date' => effective_date, 'test_id' => test_id})
+        qr.calculate({'oid_dictionary' => oid_dictionary}, false) unless qr.calculated?
+      end
+
+      # Export report
+      exporter =  HealthDataStandards::Export::Cat3.new
+      qrda_cat3 = exporter.export(HealthDataStandards::CQM::Measure.top_level.where(measures_filter),
+                                  generate_header(provider),
+                                  effective_date.to_i, start_date, end_date,
+                                  nil, test_id)
+
+      render xml: qrda_cat3, content_type: "attachment/xml"
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ PopHealth::Application.routes.draw do
 
   namespace :api do
     match 'reports/qrda_cat3.xml', :to =>'reports#cat3', :format => :xml
+    match 'reports/qrda_cat3_inplace', :to => 'reports#cat3_inplace', :format => :xml
     resources :providers do
       resources :patients do
         collection do

--- a/lib/tasks/mongo.rake
+++ b/lib/tasks/mongo.rake
@@ -13,10 +13,22 @@ namespace :db do
   end
   
   task :load_race_and_ethnicity do
-    MONGO_DB['races'].drop
-    fixture_json = JSON.parse(File.read(File.join(Rails.root, 'test', 'fixtures', 'code_sets', 'raceandethnicity.json')))
-    fixture_json.each do |document|
-      MONGO_DB['races'].save(document)
+    # Re-init races and ethnicities
+    MONGO_DB['races'].drop() if MONGO_DB['races']
+    JSON.parse(File.read(File.join(Rails.root, 'test', 'fixtures', 'code_sets', 'races.json'))).each do |document|
+      MONGO_DB['races'].insert(document)
+    end
+
+    MONGO_DB['ethnicities'].drop() if MONGO_DB['ethnicities']
+    JSON.parse(File.read(File.join(Rails.root, 'test', 'fixtures', 'code_sets', 'ethnicities.json'))).each do |document|
+      MONGO_DB['ethnicities'].insert(document)
+    end
+
+    # Additionally add languages if not found
+    if MONGO_DB['languages'].find.count == 0
+      JSON.parse(File.read(File.join(Rails.root, 'test', 'fixtures', 'code_sets', 'languages.json'))).each do |document|
+        MONGO_DB['languages'].insert(document)
+      end
     end
   end
 end


### PR DESCRIPTION
Additional api operation which allows to calculate and generate QRDA Category 3 reports based on supplied zip of patient Category 1 files. Multiple requests can perform such calculations independently.

Please, review and let me know if you find fit for such operation in main repository of popHealth.
