### PR TITLE
tie a query to the relationship between a measure and a provider

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -18,8 +18,10 @@ class Thorax.Models.Submeasure extends Thorax.Model
   url: -> "/api/measures/#{@get('id')}"
   initialize: ->
     # FIXME don't use hardcoded effective date
+    # TODO remove @get('query') when we upgrade to Thorax 3
     query = new Thorax.Models.Query({measure_id: @get('id'), sub_id: @get('sub_id'), effective_date: Config.effectiveDate}, parent: this)
     @set 'query', query
+    @queries = {}
   isPopulated: -> @has 'IPP'
   fetch: (options = {}) ->
     options.data = {sub_id: @get('sub_id')} unless options.data?
@@ -38,6 +40,10 @@ class Thorax.Models.Submeasure extends Thorax.Model
       attrs[population.type] = new Thorax.Models.Population population, parse: true
       attrs[population.type].parent = this
     attrs
+  getQueryForProvider: (providerId) ->
+    query = @queries[providerId] or new Thorax.Models.Query({measure_id: @get('id'), sub_id: @get('sub_id'), effective_date: Config.effectiveDate, providers: [providerId]}, parent: this)
+    @queries[providerId] ?= query
+
 
 class SubCollection extends Thorax.Collection
   model: Thorax.Models.Submeasure

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -36,6 +36,7 @@ class Thorax.Views.DashboardSubmeasureView extends Thorax.View
   events:
     rendered: ->
       @$("[rel='popover']").popover()
+      # TODO when we upgrade to Thorax 3, use `getQueryForProvider`
       query = @model.get('query')
       unless query.isPopulated()
         @$el.fadeTo 'fast', 0.5

--- a/app/assets/javascripts/views/measure.js.coffee
+++ b/app/assets/javascripts/views/measure.js.coffee
@@ -2,7 +2,7 @@ class Thorax.Views.MeasureView extends Thorax.LayoutView
   id: 'measureSummary'
   template: JST['measures/show']
   initialize: ->
-    @queryView = new Thorax.Views.QueryView model: @measure.get('query'), providerId: @providerId
+    @queryView = new Thorax.Views.QueryView model: @measure.getQueryForProvider(@providerId), providerId: @providerId
 
   context: ->
     _(super).extend @measure.toJSON(), measurementPeriod: moment(Config.effectiveDate * 1000).format('YYYY')
@@ -13,7 +13,7 @@ class Thorax.Views.MeasureView extends Thorax.LayoutView
     @setView view
 
   activatePatientResultsView: (providerId) ->
-    view = new Thorax.Views.PatientResultsLayoutView query: @measure.get('query'), providerId: providerId
+    view = new Thorax.Views.PatientResultsLayoutView query: @measure.getQueryForProvider(providerId), providerId: providerId
     view.changeFilter @queryView.currentPopulation
     @setView view
 

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -3,17 +3,11 @@ class Thorax.Views.ProviderView extends Thorax.View
   initialize: ->
     @dashboardView = new Thorax.Views.Dashboard provider_id: @model.id, collection: new Thorax.Collections.Categories PopHealth.categories, parse: true
     @providerChart = PopHealth.viz.providerChart()
-  # Code for eventual partial replacement of
-  # changeProvider: (event) ->
-  #    providerId = $(event.currentTarget).attr("id") # selected ID
-  #    @setModel(new Thorax.Models.Provider(_id: providerId))
-  #    @dashboardView.remove()
   context: ->
     _(super).extend
       providerType: @model.providerType() || ""
       providerExtension: @model.providerExtension() || ""
   events:
-    # 'click g': 'changeProvider'
     rendered: ->
       if @model.isPopulated()
         d3.select(@el).select("#providerChart").datum(@model.toJSON()).call(@providerChart)


### PR DESCRIPTION
Previously, a query was a direct child of a measure.

If additional filters are ever used, we'll probably want to make this more universal.

When we can upgrade to Thorax 3, we'll want to use `getQueryForProvider` in the `DashboardSubmeasureView` view as well. Currently, it's too difficult to supply the view with a provider_id, but it'll be easier once https://github.com/walmartlabs/thorax/pull/358 is pulled in.
