### PR TITLE
Allows M/R jobs in popHealth to use prefiltering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'http://rubygems.org'
 
 gem 'rails', '3.2.14'
-gem 'quality-measure-engine', '3.0.1'
+gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git'
 
-gem 'health-data-standards', '3.4.5'
+gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git'
 gem 'nokogiri'
 gem 'rubyzip'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,30 @@
+GIT
+  remote: https://github.com/pophealth/quality-measure-engine.git
+  revision: f799560639329d8ca118d8f9d4560b04c80134ca
+  specs:
+    quality-measure-engine (3.0.1)
+      delayed_job_mongoid (~> 2.0.0)
+      mongoid (~> 3.1.4)
+      moped (~> 1.5.1)
+      rubyzip (~> 0.9.9)
+
+GIT
+  remote: https://github.com/projectcypress/health-data-standards.git
+  revision: b43c95b38231be0655b49bc755b1ed90200ec182
+  specs:
+    health-data-standards (3.4.5)
+      activesupport (~> 3.2.14)
+      builder (~> 3.0.0)
+      erubis (~> 2.7.0)
+      log4r (~> 1.1.10)
+      memoist (~> 0.9.1)
+      mongoid (~> 3.1.4)
+      mongoid-tree (~> 1.0.4)
+      nokogiri (= 1.6.0)
+      rest-client (~> 1.6.7)
+      rubyzip (= 0.9.9)
+      uuid (~> 2.3.7)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -35,9 +62,8 @@ GEM
       json
       rails (>= 3.0.10)
     arel (3.0.3)
-    atomic (1.1.16)
     bcrypt (3.1.7)
-    bootstrap-sass (3.1.1.0)
+    bootstrap-sass (3.1.1.1)
       sass (~> 3.2)
     builder (3.0.4)
     cancan (1.6.10)
@@ -49,7 +75,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
-    columnize (0.3.6)
+    columnize (0.8.9)
     commonjs (0.2.7)
     daemons (1.1.9)
     debugger (1.6.6)
@@ -70,15 +96,15 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     docile (1.1.3)
-    dotenv (0.10.0)
+    dotenv (0.7.0)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (2.0.2)
     factory_girl (2.6.3)
       activesupport (>= 2.3.9)
-    foreman (0.63.0)
-      dotenv (>= 0.7)
-      thor (>= 0.13.6)
+    foreman (0.66.0)
+      dotenv (~> 0.7.0)
+      thor (~> 0.19.1)
     formtastic (2.2.1)
       actionpack (>= 3.0)
     git (1.2.6)
@@ -87,18 +113,6 @@ GEM
       multi_json
       sprockets (>= 2.0.3)
       tilt
-    health-data-standards (3.4.5)
-      activesupport (~> 3.2.14)
-      builder (~> 3.0.0)
-      erubis (~> 2.7.0)
-      log4r (~> 1.1.10)
-      memoist (~> 0.9.1)
-      mongoid (~> 3.1.4)
-      mongoid-tree (~> 1.0.4)
-      nokogiri (= 1.6.0)
-      rest-client (~> 1.6.7)
-      rubyzip (= 0.9.9)
-      uuid (~> 2.3.7)
     highline (1.6.21)
     hike (1.2.3)
     i18n (0.6.9)
@@ -121,12 +135,12 @@ GEM
       less (~> 2.5.0)
     libv8 (3.16.14.3)
     log4r (1.1.10)
-    macaddr (1.7.0)
+    macaddr (1.7.1)
       systemu (~> 2.6.2)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    memoist (0.9.1)
+    memoist (0.9.2)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -142,7 +156,7 @@ GEM
     mongoid-tree (1.0.4)
       mongoid (>= 3.0, <= 4.0)
     moped (1.5.2)
-    multi_json (1.9.2)
+    multi_json (1.9.3)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     origin (1.1.0)
@@ -156,11 +170,6 @@ GEM
     pry-debugger (0.2.2)
       debugger (~> 1.3)
       pry (~> 0.9.10)
-    quality-measure-engine (3.0.1)
-      delayed_job_mongoid (~> 2.0.0)
-      mongoid (~> 3.1.4)
-      moped (~> 1.5.1)
-      rubyzip (~> 0.9.9)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -184,14 +193,14 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.13.0)
-    rake (10.2.2)
+    rake (10.3.1)
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rubyzip (0.9.9)
-    sass (3.3.4)
+    sass (3.3.6)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
@@ -216,8 +225,7 @@ GEM
       eventmachine (>= 1.0.0)
       rack (>= 1.0.0)
     thor (0.19.1)
-    thread_safe (0.3.1)
-      atomic (>= 1.1.7, < 2)
+    thread_safe (0.3.3)
     tilt (1.4.1)
     treetop (1.4.15)
       polyglot
@@ -254,7 +262,7 @@ DEPENDENCIES
   formtastic
   git
   handlebars_assets
-  health-data-standards (= 3.4.5)
+  health-data-standards!
   highline
   jasmine (= 2.0.0)
   jquery-rails
@@ -267,7 +275,7 @@ DEPENDENCIES
   nokogiri
   pry
   pry-debugger
-  quality-measure-engine (= 3.0.1)
+  quality-measure-engine!
   rails (= 3.2.14)
   rubyzip
   sass-rails

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -20,6 +20,7 @@ defaults: &defaults
   ccr_system_name: popHealth
   # force the system to allow HTTP connections
   force_unsecure_communications: true
+  use_map_reduce_prefilter: true
   value_sets:
     ticket_url: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     api_url: https://vsac.nlm.nih.gov/vsac/ws/RetrieveValueSet
@@ -60,7 +61,7 @@ defaults: &defaults
         :extension: legal_authenticator_ext
       :addresses: []
       :telecoms: []
-      :time: 
+      :time:
       :person:
         :given:
         :family:


### PR DESCRIPTION
This pull request allows popHealth to take advantage of the prefiltering support
that has been built into QME and HDS. It is configurable, and on by default, in
config/popHealth.yml.

When prefiltering is enabled, a query is created based on the CQM logic. This
query will be passed to MongoDB as filter for documents to run through the Map
Reduce job. Depending on the measure, this can have a big performance
improvement on measure calculation times.

This commit switches the pointers to HDS and QME in the Gemfile from fixed
versions to their git repos. These should be changed when the gems with the new
functionality are released.
