### PR TITLE
Workaround issue where log file is not written to until delayed job exits

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,10 @@ require 'rake'
 # require 'rspec/core/rake_task'
 # require 'resque/tasks'
 
+# This fixes errors in the delayed job where the log file will not be written to 
+# until the delayed job exits.
+STDOUT.sync = true
+
 PopHealth::Application.load_tasks
 
 ENV['DB_NAME'] = "pophealth-#{Rails.env}"


### PR DESCRIPTION
Currently when you run the delayed job worker, nothing is dumped to the log file until you exit the delayed job worker. Setting STDOUT.sync to true fixes this.
