### PR TITLE
Calling get with no assert_response causes the test to not actually validate anything.

### DIFF
--- a/test/functional/api/patients_controller_test.rb
+++ b/test/functional/api/patients_controller_test.rb
@@ -13,6 +13,7 @@ require 'test_helper'
 
     test "view patient" do
       get :show, id: '523c57e1b59a907ea9000064'
+      assert_response :success
     end
 
     test "view patient with include_results includes the results" do


### PR DESCRIPTION
Adding a basic validation to make sure the request actually succeeded.
