### PR TITLE
Add polling for admin patient count.

### DIFF
--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -34,6 +34,15 @@
       respond_with  paginate(api_patients_url,records)
     end
 
+    api :GET, "/patients/count", "Get count of patients in the database"
+    formats ['json']
+    example '{"patient_count":56}'
+    def count
+      json = {}
+      json['patient_count'] = Record.count
+      render :json => json
+    end
+
     api :GET, "/patients/:id[?include_results=:include_results]", "Retrieve an individual patient"
     formats ['json']
     param :id, String, :desc => "Patient ID", :required => true

--- a/app/views/admin/patients.html.erb
+++ b/app/views/admin/patients.html.erb
@@ -5,7 +5,7 @@
 
     <tr><td>patients loaded: </td>
       <td>
-        <%= @patient_count %> patients
+        <span id="patient_count"><%= @patient_count %></span> patients
       </td>
       <td>
         <%= button_to "Delete Patients", "/admin/remove_patients", 'method' => 'delete', 'class' => 'btn btn-danger'%>
@@ -67,5 +67,14 @@
         e.preventDefault();
       }
     });
+    (function poll(){
+       setTimeout(function(){
+        $.ajax({ url: "<%= api_patients_count_path %>", success: function(data){
+          document.getElementById('patient_count').innerHTML = data.patient_count;
+          //Setup the next poll recursively
+          poll();
+        }, dataType: "json"});
+      }, 5000);
+    })();
   });
 </script>

--- a/app/views/admin/patients.html.erb
+++ b/app/views/admin/patients.html.erb
@@ -69,11 +69,11 @@
     });
     (function poll(){
        setTimeout(function(){
-        $.ajax({ url: "<%= api_patients_count_path %>", success: function(data){
-          document.getElementById('patient_count').innerHTML = data.patient_count;
+        $.getJSON( "<%= api_patients_count_path %>", function(data){
+          $('#patient_count').html(data.patient_count);
           //Setup the next poll recursively
           poll();
-        }, dataType: "json"});
+        });
       }, 5000);
     })();
   });

--- a/app/views/admin/patients.html.erb
+++ b/app/views/admin/patients.html.erb
@@ -69,7 +69,7 @@
     });
     (function poll(){
        setTimeout(function(){
-        $.getJSON( "<%= api_patients_count_path %>", function(data){
+        $.getJSON( "<%= count_api_patients_path %>", function(data){
           $('#patient_count').html(data.patient_count);
           //Setup the next poll recursively
           poll();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ PopHealth::Application.routes.draw do
   resources :teams
 
   namespace :api do
+    get 'patients/count', :to => 'patients#count'
     get 'reports/qrda_cat3.xml', :to =>'reports#cat3', :format => :xml
     get 'reports/cat1/:id/:measure_ids', :to =>'reports#cat1', :format => :xml
     resources :providers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,6 @@ PopHealth::Application.routes.draw do
   resources :teams
 
   namespace :api do
-    get 'patients/count', :to => 'patients#count'
     get 'reports/qrda_cat3.xml', :to =>'reports#cat3', :format => :xml
     get 'reports/cat1/:id/:measure_ids', :to =>'reports#cat1', :format => :xml
     resources :providers do
@@ -50,6 +49,9 @@ PopHealth::Application.routes.draw do
       end
     end
     resources :patients do
+      collection do
+        get :count
+      end
       member do
         get :results
       end

--- a/test/functional/api/patients_controller_test.rb
+++ b/test/functional/api/patients_controller_test.rb
@@ -16,6 +16,13 @@ require 'test_helper'
       assert_response :success
     end
 
+    test "count number of patients" do
+      get :count
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert_equal 8, json['patient_count']
+    end
+
     test "view patient with include_results includes the results" do
       @record = Record.find('523c57e1b59a907ea9000064')
 


### PR DESCRIPTION
This adds the ability for users to have a more up-to-date representation of how many patients are in the database. This is a working version however it does not do any sort of smart polling, however smart polling can be added if it is determined it is needed.
