### PR TITLE
force IE to not use compatibility mode

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="x-ua-compatible" content="IE=edge">
   <meta http-equiv="content-script-type" content="text/javascript">
   
   <title>popHealth : An Open Source Quality Measure Reference Implementation</title>

--- a/app/views/layouts/users.html.erb
+++ b/app/views/layouts/users.html.erb
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta http-equiv="Cache-Control" content="no-cache" />
+  <meta charset="utf-8">
+  <meta http-equiv="Cache-Control" content="no-cache">
+  <meta http-equiv="x-ua-compatible" content="IE=edge">
   <title>popHealth : An Open Source Quality Measure Reference Implementation</title>
-  <link rel="shortcut icon" href="/favicon.ico"/>
+  <link rel="shortcut icon" href="/favicon.ico">
 
   <%= stylesheet_link_tag 'application' %>
   <%= javascript_include_tag "application" %>


### PR DESCRIPTION
This addresses using popHealth on IE on an intranet, as IE by default will display intranet sites in compatibility mode.
