### PR TITLE
configure Rails to create non-digest versions of vendored assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier'
 gem "bootstrap-sass"
+gem 'non-stupid-digest-assets' # support vendored non-digest assets
 
 group :test, :develop, :ci do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
     net-ssh (2.7.0)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
+    non-stupid-digest-assets (1.0.4)
     optionable (0.2.0)
     origin (2.1.1)
     orm_adapter (0.5.0)
@@ -286,6 +287,7 @@ DEPENDENCIES
   mocha
   mongoid
   nokogiri
+  non-stupid-digest-assets
   protected_attributes (~> 1.0.5)
   pry
   pry-debugger

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,8 @@ PopHealth::Application.configure do
   config.assets.precompile << '*.scss'
   config.assets.precompile << 'jquery.js'
   config.assets.precompile << 'jquery_ujs.js'
+  config.assets.precompile << 'bootstrap/fonts/glyphicons-halflings-regular.*'
+  config.assets.precompile << 'font-awesome/fonts/fontawesome-webfont.*'
 
   # Defaults to Rails.root.join("public/assets")
   # config.assets.manifest = YOUR_PATH

--- a/config/initializers/non_digest_assets.rb
+++ b/config/initializers/non_digest_assets.rb
@@ -1,0 +1,1 @@
+NonStupidDigestAssets.whitelist = [/glyphicons-halflings-regular.*/, /fontawesome-webfont.*/]


### PR DESCRIPTION
Rails in v4 has stopped supporting non-digest assets in production. This would require any vendored assets to be managed through the asset pipeline as a gem. (See rails/sprockets-rails#49 for more information.) There are a few different ways to get around this, but using https://github.com/alexspeller/non-stupid-digest-assets seems to be the simplest, sanest way to go.
