### PR TITLE
Added logging when a user is added to the default orphan provider.

### DIFF
--- a/lib/hds/provider.rb
+++ b/lib/hds/provider.rb
@@ -52,14 +52,16 @@ class Provider
     super(options)
   end
 
-  def self.resolve_provider(provider_hash)
+  def self.resolve_provider(provider_hash, patient=nil)
     catch_all_provider_hash = { :title => "",
                                 :given_name => "",
                                 :family_name=> "",
                                 :specialty => "",
                                 :cda_identifiers => [{root: APP_CONFIG['orphan_provider']['root'], extension:APP_CONFIG['orphan_provider']['extension']}]
                               }
-    Log.create(:username => 'Background Event', :event => 'No such provider exists in the database for the imported patient, patient has been assigned to the orphan provider.')
+    provider_info = provider_hash[:cda_identifiers].first
+    patient_id = patient.medical_record_number if patient
+    Log.create(:username => 'Background Event', :event => "No such provider with root '#{provider_info.root}' and extension '#{provider_info.extension}' exists in the database, patient has been assigned to the orphan provider.", :medical_record_number => patient_id)
     provider ||= Provider.in("cda_identifiers.root" => APP_CONFIG['orphan_provider']['root']).and.in("cda_identifiers.extension" => APP_CONFIG['orphan_provider']['extension']).first
     if provider.nil?
       provider = Provider.create(catch_all_provider_hash)

--- a/lib/hds/provider.rb
+++ b/lib/hds/provider.rb
@@ -59,6 +59,7 @@ class Provider
                                 :specialty => "",
                                 :cda_identifiers => [{root: APP_CONFIG['orphan_provider']['root'], extension:APP_CONFIG['orphan_provider']['extension']}]
                               }
+    Log.create(:username => 'unknown', :event => 'No such provider exists in the database for the imported patient, patient has been assigned to the orphan provider.')
     provider ||= Provider.in("cda_identifiers.root" => APP_CONFIG['orphan_provider']['root']).and.in("cda_identifiers.extension" => APP_CONFIG['orphan_provider']['extension']).first
     if provider.nil?
       provider = Provider.create(catch_all_provider_hash)

--- a/lib/hds/provider.rb
+++ b/lib/hds/provider.rb
@@ -59,7 +59,7 @@ class Provider
                                 :specialty => "",
                                 :cda_identifiers => [{root: APP_CONFIG['orphan_provider']['root'], extension:APP_CONFIG['orphan_provider']['extension']}]
                               }
-    Log.create(:username => 'unknown', :event => 'No such provider exists in the database for the imported patient, patient has been assigned to the orphan provider.')
+    Log.create(:username => 'Background Event', :event => 'No such provider exists in the database for the imported patient, patient has been assigned to the orphan provider.')
     provider ||= Provider.in("cda_identifiers.root" => APP_CONFIG['orphan_provider']['root']).and.in("cda_identifiers.extension" => APP_CONFIG['orphan_provider']['extension']).first
     if provider.nil?
       provider = Provider.create(catch_all_provider_hash)


### PR DESCRIPTION
This will add a statement to the log every time that a patient is uploaded and is added to the orphan provider. Currently the amount of information logged is rather sparse. If this needs to have more information please let me know, however not much more information is provided to the resolve_provider method. For any additional information to be passed, we will have to make changes to the health-data-standards gem, as this seems to be all we can get without doing so.
