### PR TITLE
enabling rationale in map reduce jobs. This creates a list on the patien...

### DIFF
--- a/app/controllers/api/queries_controller.rb
+++ b/app/controllers/api/queries_controller.rb
@@ -57,7 +57,7 @@ module Api
                                            params[:sub_id], options)
       if !qr.calculated?
         qr.calculate( {"oid_dictionary" =>OidHelper.generate_oid_dictionary(qr.measure),
-          "enable_rationale" => true,
+          "enable_rationale" => APP_CONFIG['enable_map_reduce_rationale'] || false,
           "enable_logging" => APP_CONFIG['enable_map_reduce_logging'] || false}, true)
       end
 

--- a/app/controllers/api/queries_controller.rb
+++ b/app/controllers/api/queries_controller.rb
@@ -56,7 +56,9 @@ module Api
       qr = QME::QualityReport.find_or_create(params[:measure_id],
                                            params[:sub_id], options)
       if !qr.calculated?
-        qr.calculate({"oid_dictionary" =>OidHelper.generate_oid_dictionary(qr.measure)}, true)
+        qr.calculate( {"oid_dictionary" =>OidHelper.generate_oid_dictionary(qr.measure),
+          "enable_rationale" => true,
+          "enable_logging" => APP_CONFIG['enable_map_reduce_logging'] || false}, true)
       end
 
       render json: qr

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -21,6 +21,7 @@ defaults: &defaults
   # force the system to allow HTTP connections
   force_unsecure_communications: true
   use_map_reduce_prefilter: true
+  enable_map_reduce_rationale: true
   enable_map_reduce_logging: false
   orphan_provider:
     root: "popHealth"

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -21,6 +21,7 @@ defaults: &defaults
   # force the system to allow HTTP connections
   force_unsecure_communications: true
   use_map_reduce_prefilter: true
+  enable_map_reduce_logging: false
   orphan_provider:
     root: "popHealth"
     extension: "Orphans"


### PR DESCRIPTION
...t_cache entries for each data criteria in a measure and whetehr or not the patient had clinical data that matched that dc.  Also added a configurable flag in the popHealth.yml file for enableing verbose logging in the map reduce jobs.  This flag enables verbose logging in the mongodb map reduce portion of calculations as it steps through the measure logic.  This is off by defualt as it can exceed the 16meg limit of mongo records for certain patients ehen enabled and should be used as a debugging item only.
