### PR TITLE
Patient view: support Episode of Care measures

### DIFF
--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -1,24 +1,24 @@
 <thead>
   <tr>
-    <th class="pid">Patient ID</th>
     <th>Last Name</th>
     <th>First Name</th>
+    <th>Patient ID</th>
     <th>Age</th>
     <th>DOB</th>
     <th>Sex</th>
+    {{#if isEpisodeOfCare}}<th># Encounters</th>{{/if}}
     <th>Exclusion</th>
   </tr>
 </thead>
 {{#collection tag='tbody' item-context=patientContext}}
   <tr>
-    <td>
-      {{#link "patients/{{patient_id}}" expand-tokens=true}}{{medical_record_id}}{{/link}}
-    </td>
-    <td><strong>{{last}}</strong></td>
+    <td>{{#link "patients/{{patient_id}}" expand-tokens=true}}{{last}}{{/link}}</td>
     <td>{{first}}</td>
+    <td class="col-patient-medical-record-id" title="{{medical_record_id}}">{{medical_record_id}}</td>
     <td>{{age}}</td>
     <td>{{formatted_birthdate}}</td>
     <td>{{gender}}</td>
+    {{#if ../isEpisodeOfCare}}<td># Encounters FIXME</td>{{/if}}
     <td>
       <button class="btn-default">Exclude</button>
     </td>

--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -18,7 +18,10 @@
     <td>{{age}}</td>
     <td>{{formatted_birthdate}}</td>
     <td>{{gender}}</td>
-    {{#if ../isEpisodeOfCare}}<td># Encounters FIXME</td>{{/if}}
+    {{#if ../isEpisodeOfCare}}
+      {{!EoC measures track number of encounters in the numerator}}
+      <td>{{NUMER}}</td>
+    {{/if}}
     <td>
       <button class="btn-default">Exclude</button>
     </td>

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -33,6 +33,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
 
   initialize: ->
     @isFetching = false
+    @isEpisodeOfCare = @query.parent.get('episode_of_care')
     @scrollHandler = =>
       distanceToBottom = $(document).height() - $(window).scrollTop() - $(window).height()
       if !@isFetching and @collection?.length and @fetchTriggerPoint > distanceToBottom

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -203,10 +203,6 @@ $table-border-color: white;
     > tr > th {
       border: none;
       font-weight: 700;
-      &.pid {
-        text-transform: uppercase;
-        font-size: 1.2em;
-      }
     }
   }
   > thead > tr > th, > tbody > tr > td {
@@ -219,7 +215,11 @@ $table-border-color: white;
   }
 }
 
-
+.col-patient-medical-record-id {
+  max-width: 115px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 
 

--- a/spec/javascripts/views/patient_results_view.spec.js.coffee
+++ b/spec/javascripts/views/patient_results_view.spec.js.coffee
@@ -1,9 +1,11 @@
 describe 'PatientResultsView', ->
   beforeEach ->
-    json = loadJSONFixtures 'query.json', 'queries/patient_results.json', 'users.json'
+    json = loadJSONFixtures 'query.json', 'submeasure.json', 'queries/patient_results.json', 'users.json'
     window.PopHealth.currentUser = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
     jasmine.Ajax.install()
-    query = new Thorax.Models.Query json['query.json'], parse: true
+    @json = getJSONFixture 
+    submeasure = new Thorax.Models.Submeasure json['submeasure.json'], parse: true
+    query = new Thorax.Models.Query json['query.json'], parse: true, parent: submeasure
     @patientResultsView = new Thorax.Views.PatientResultsView query: query
     jasmine.Ajax.requests.mostRecent().response responseText: JSON.stringify(json['queries/patient_results.json'][2...4]), status: 200
 


### PR DESCRIPTION
This adds an extra "# Encounters" column for Episode of Care measures, displaying the number of encounters per patient. It also rearranges the patient columns slightly, placing more emphasis on the name and limits the size of the patient ID column.
