### PR TITLE
Login ui updates

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
 
   <%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => {:name=>"login_form"}) do |f| %>
   <div class="form-group input-group input-group-lg">
-      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+      <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
       <%= f.text_field :username, class: "form-control", placeholder: "username" %>
   </div>
   <div class="form-group input-group input-group-lg">
@@ -28,4 +28,3 @@
   <%= render :partial => "devise/shared/links" %>
 <% end %>
 </div>
-

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -17,7 +17,7 @@ en:
       unauthenticated: 'You need to sign in or sign up before continuing.'
       unconfirmed: 'You have to confirm your account before continuing.'
       locked: 'Your account is locked.'
-      invalid: 'Invalid email or password.'
+      invalid: 'Invalid username or password.'
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'


### PR DESCRIPTION
Updated the verbiage for the Devise "locked" message (bad username or password input) to "Invalid username or password" from "Invalid email or password", and changed the login FontAwesome icon from fa-envelope to fa-user.
