### PR TITLE
Misc Registration and User Edit Fixes

### DIFF
--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -9,4 +9,9 @@ class Bundle
   field :exported, type: String
   field :extensions, type: Array
 
+  def license
+    read_attribute(:license)
+      .gsub(/\\("|')/,'\1') # Remove \ characters from in front of ' or " in the bundle.
+      .gsub(/\\n|",$/,' ') # Remove \n from printing out and get rid of ", at end of bundle, replace with space.
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -24,16 +24,16 @@
     </div>
     <div class="form-group row">
       <div class="col-md-6">
-        <div class="input-group input-group-lg">
+        <div class="input-group input-group-lg required">
           <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
-          <%= f.text_field :username, class: "form-control", placeholder: "username" %>
+          <%= f.text_field :username, class: "form-control", placeholder: "username*" %>
         </div>
         <p class="help-block">Must be at least 3 characters long.</p>
       </div>
       <div class="col-md-6">
-        <div class="input-group input-group-lg">
+        <div class="input-group input-group-lg required">
           <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
-          <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+          <%= f.email_field :email, class: "form-control", placeholder: "email@example.com*" %>
         </div>
       </div>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -34,7 +34,7 @@
           <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
           <%= f.text_field :username, class: "form-control", placeholder: "username" %>
         </div>
-        Must be at least 3 characters long.
+        <p class="help-block">Must be at least 3 characters long.</p>
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg">
@@ -92,7 +92,7 @@
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
           <%= f.password_field :password, class: "form-control", placeholder: "password" %>
         </div>
-        leave blank if you don't want to change it
+        <p class="help-block">Leave blank if you don't wish to change.</p>
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg">
@@ -107,7 +107,7 @@
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
           <%= f.password_field :current_password, class: "form-control", placeholder: "current password*" %>
         </div>
-        to confirm your changes.
+        <p class="help-block">Please provide your old password.</p>
       </div>
     </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -34,7 +34,7 @@
           <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
           <%= f.text_field :username, class: "form-control", placeholder: "username" %>
         </div>
-        at least 5 characters long.
+        Must be at least 3 characters long.
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -52,7 +52,7 @@
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+          <span class="input-group-addon"><i class="fa fa-link fa-lg fa-fw"></i></span>
           <%= f.text_field :company_url, class: "form-control", placeholder: "www.company.com" %>
         </div>
       </div>
@@ -60,13 +60,13 @@
     <div class="form-group row">
       <div class="col-md-6">
         <div class="input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+          <span class="input-group-addon"><i class="fa fa-h-square fa-lg fa-fw"></i></span>
           <%= f.text_field :registry_name, class: "form-control", placeholder: "registry name" %>
         </div>
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+          <span class="input-group-addon"><i class="fa fa-archive fa-lg fa-fw"></i></span>
           <%= f.text_field :registry_id, class: "form-control", placeholder: "registry identifier" %>
         </div>
       </div>
@@ -74,13 +74,13 @@
     <div class="form-group row">
       <div class="col-md-6">
         <div class="input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+          <span class="input-group-addon"><i class="fa fa-hospital-o fa-lg fa-fw"></i></span>
           <%= f.text_field :npi, class: "form-control", placeholder: "national provider id" %>
         </div>
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+          <span class="input-group-addon"><i class="fa fa-folder fa-lg fa-fw"></i></span>
           <%= f.text_field :tin, class: "form-control", placeholder: "tax id number" %>
         </div>
       </div>
@@ -88,16 +88,16 @@
 
     <div class="form-group row">
       <div class="col-md-6">
-        <div class="input-group input-group-lg required">
+        <div class="input-group input-group-lg">
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
-          <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
+          <%= f.password_field :password, class: "form-control", placeholder: "password" %>
         </div>
         leave blank if you don't want to change it
       </div>
       <div class="col-md-6">
-        <div class="input-group input-group-lg required">
+        <div class="input-group input-group-lg">
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
-          <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+          <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password" %>
         </div>
       </div>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,10 +1,4 @@
-<div class="navbar navbar-default" role="navigation">
-  <div class="container">
-    <div class="navbar-header col-lg-4">
-      <a class="logo"  href="/" style="max-width: initial"><%= image_tag "pophealth_logo_small-trans.png" %></a>
-    </div>
-  </div>
-</div>
+<%= render partial: "shared/header" %>
 
 <div class="container">
   <div class="register-body">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -95,13 +95,13 @@
         <p class="help-block">Leave blank if you don't wish to change.</p>
       </div>
       <div class="col-md-6">
-        <div class="input-group input-group-lg">
+        <div class="input-group input-group-lg hidden-toggle required">
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
-          <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password" %>
+          <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
         </div>
       </div>
     </div>
-    <div class="form-group row" style="margin-top: 30px">
+    <div class="form-group row hidden-toggle" style="margin-top: 30px">
       <div class="col-md-6">
         <div class="input-group input-group-lg required">
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
@@ -161,3 +161,17 @@
     <% end -%>
   </div>
 </div>
+
+<script>
+  $(function() {
+    $('.hidden-toggle').hide();
+    $('#user_password').on('keyup', function(e) {
+      if($(this).val().length > 0) {
+        $('.hidden-toggle').show();
+      }
+      else {
+        $('.hidden-toggle').val('').hide();
+      }
+    });
+  });
+</script>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -33,7 +33,7 @@
           <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
           <%= f.text_field :username, class: "form-control", placeholder: "username*" %>
         </div>
-        Must be at least 5 characters long.
+        Must be at least 3 characters long.
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg required">
@@ -48,7 +48,7 @@
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
           <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
         </div>
-        Must be at least 8 characters long.
+        Must be at least 6 characters long.
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg required">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -33,7 +33,7 @@
           <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
           <%= f.text_field :username, class: "form-control", placeholder: "username*" %>
         </div>
-        Must be at least 3 characters long.
+        <p class="help-block">Must be at least 3 characters long.</p>
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg required">
@@ -48,7 +48,7 @@
           <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
           <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
         </div>
-        Must be at least 6 characters long.
+        <p class="help-block">Must be at least 6 characters long.</p>
       </div>
       <div class="col-md-6">
         <div class="input-group input-group-lg required">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -29,16 +29,16 @@
     </div>
     <div class="form-group row">
       <div class="col-md-6">
-        <div class="input-group input-group-lg">
+        <div class="input-group input-group-lg required">
           <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
-          <%= f.text_field :username, class: "form-control", placeholder: "username" %>
+          <%= f.text_field :username, class: "form-control", placeholder: "username*" %>
         </div>
         Must be at least 5 characters long.
       </div>
       <div class="col-md-6">
-        <div class="input-group input-group-lg">
+        <div class="input-group input-group-lg required">
           <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
-          <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+          <%= f.email_field :email, class: "form-control", placeholder: "email@example.com*" %>
         </div>
       </div>
     </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,9 +20,9 @@ en:
       invalid: 'Invalid username or password.'
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
-      inactive: 'Your account was not activated yet.'
+      inactive: 'Your account is not active.'
       not_found_in_database: "Invalid username or password."
-      not_approved: 'Your account was not approved yet.'
+      not_approved: 'Your account was not approved.'
     sessions:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -22,6 +22,7 @@ en:
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'
       not_found_in_database: "Invalid username or password."
+      not_approved: 'Your account was not approved yet.'
     sessions:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'


### PR DESCRIPTION
This fixes the following issues:

Register view legal text should not include “/n” characters
Register view username and email fields should be required fields
Register view username and password field minimum character lengths should match error notification message
Account Info view icons should match Register view icons for matching fields
Register view username and password field subtext: alignment & padding
Password field on the account info page should not show as required, as the user is not required to change their password.
Account Info view should include navigation menu to match popHealth design
Account Info view reset password fields should be a separate section and intuitive
