### PR TITLE
Override default password not found message on login page

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -21,6 +21,7 @@ en:
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'
+      not_found_in_database: "Invalid username or password."
     sessions:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'


### PR DESCRIPTION
Needed to add one more string to the devise.en.yml file, for the "not_found_in_database" message. As it wasn't present, it was defaulting to the default, "Invalid email or password", instead of the desired "Invalid username or password".
