### PR TITLE
Center the login form on the page.

### DIFF
--- a/app/assets/stylesheets/_login.scss
+++ b/app/assets/stylesheets/_login.scss
@@ -1,7 +1,8 @@
 
 .login {
-  // center horizontally, give it some breathing room across the top
-  margin-top: 200px;
+  // give it some breathing room across the top
+  margin-top: 20px;
+  margin-bottom: $bottom-margin; // Declared in _variables.css.scss
   @include make-sm-column(4);
   @include make-sm-column-offset(4);
 
@@ -32,6 +33,7 @@
 }
 
 .register-body {
+  margin-bottom: $bottom-margin;
   #termsAndConditions {
     @extend .well;
     max-height: 250px;

--- a/app/assets/stylesheets/_login.scss
+++ b/app/assets/stylesheets/_login.scss
@@ -1,10 +1,10 @@
-
 .login {
   // give it some breathing room across the top
   margin-top: 20px;
-  margin-bottom: $bottom-margin; // Declared in _variables.css.scss
-  @include make-sm-column(4);
-  @include make-sm-column-offset(4);
+  @include center-block();
+  @media (min-width: $screen-sm-min) {
+    width: percentage(1/3);
+  }
 
   header img {
     width: 100%;
@@ -33,7 +33,10 @@
 }
 
 .register-body {
-  margin-bottom: $bottom-margin;
+  @media (min-width: $screen-sm-min) {
+    width: percentage(2/3);
+  }
+  @include center-block();
   #termsAndConditions {
     @extend .well;
     max-height: 250px;
@@ -42,8 +45,4 @@
   .required {
     @include form-control-validation($brand-primary, $brand-primary, $input-bg);
   }
-}
-.register-body {
-  @include make-sm-column(8);
-  @include make-sm-column-offset(2);
 }

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -5,7 +5,7 @@ $title-circle-radius: 21px;
 // Custom styles that are part of the theme
 
 body {
-  margin-bottom: $bottom-margin; // Declared in _variables.css.scss
+  margin-bottom: 40px;
 }
 
 .fraction-listing {

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -4,6 +4,10 @@ $title-circle-radius: 21px;
 
 // Custom styles that are part of the theme
 
+body {
+  margin-bottom: $bottom-margin; // Declared in _variables.css.scss
+}
+
 .fraction-listing {
   margin-top: 10px;
   margin-bottom: 10px;

--- a/app/assets/stylesheets/_variables.css.scss
+++ b/app/assets/stylesheets/_variables.css.scss
@@ -1,4 +1,1 @@
 $fa-font-path: "font-awesome/fonts";
-// Since the registration and login pages set the body height to 0, the bottom margin must be set in 3 places, 
-// thus it is declared as a variable in order to simplify changing it if needed.
-$bottom-margin: 40px;

--- a/app/assets/stylesheets/_variables.css.scss
+++ b/app/assets/stylesheets/_variables.css.scss
@@ -1,1 +1,4 @@
 $fa-font-path: "font-awesome/fonts";
+// Since the registration and login pages set the body height to 0, the bottom margin must be set in 3 places, 
+// thus it is declared as a variable in order to simplify changing it if needed.
+$bottom-margin: 40px;


### PR DESCRIPTION
I have tested this in IE9, Chrome, Safari, and Firefox and it seems to work in each of them as intended. This causes the login screen to center on the page instead of being pushed to the bottom.
