### PR TITLE
add basic support to CV measures within the dashboard

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -49,4 +49,3 @@ class SubCollection extends Thorax.Collection
   model: Thorax.Models.Submeasure
   initialize: (models, options) -> @parent = options.parent
   comparator: 'sub_id'
-

--- a/app/assets/javascripts/models/query.js.coffee
+++ b/app/assets/javascripts/models/query.js.coffee
@@ -7,17 +7,21 @@ class Thorax.Models.Query extends Thorax.Model
   # TODO what other final states are there other than completed?
   isPopulated: -> @has('status') and @get('status').state in ['completed']
   isLoading: -> !@isPopulated()
+  isContinuous: -> @has('population_ids') and @get('population_ids').hasOwnProperty('MSRPOPL')
   ipp: -> if @isPopulated() and @has('result') then @get('result').IPP else 0
+  msrpopl: -> if @isPopulated and @has('result') then @get('result').MSRPOPL else 0
   numerator: -> if @isPopulated() and @has('result') then @get('result').NUMER else 0
   denominator: -> if @isPopulated() and @has('result') then @get('result').DENOM else 0
+  observ: -> if @isPopulated() and @has('result') then @get('result').OBSERV else 0
   hasExceptions: -> @has('population_ids') and @get('population_ids').hasOwnProperty('DENEXCEP')
   exceptions: -> if @isPopulated() and @has('result') then @get('result').DENEXCEP else 0
   hasExclusions: -> @has('population_ids') and @get('population_ids').hasOwnProperty('DENEX')
   exclusions: -> if @isPopulated() and @has('result') then @get('result').DENEX else 0
-  hasOutliers: -> @has('antinumerator')
+  hasOutliers: -> !@isContinuous and @has('antinumerator')
   outliers: -> if @isPopulated() and @has('result') then @get('result').antinumerator else 0
   performanceDenominator: -> @denominator() - @exceptions() - @exclusions()
   performanceRate: -> Math.round(100 * @numerator() / Math.max(1, @performanceDenominator()))
+
   # hack so that creating a query acts just like checking an existing query
   fetch: -> if @isNew() then @save() else super(arguments...)
   result: -> _(@get('result')).extend performanceDenominator: @performanceDenominator()

--- a/app/assets/javascripts/models/query.js.coffee
+++ b/app/assets/javascripts/models/query.js.coffee
@@ -7,17 +7,17 @@ class Thorax.Models.Query extends Thorax.Model
   # TODO what other final states are there other than completed?
   isPopulated: -> @has('status') and @get('status').state in ['completed']
   isLoading: -> !@isPopulated()
-  isContinuous: -> @has('population_ids') and @get('population_ids').hasOwnProperty('MSRPOPL')
+  isContinuous: -> @parent.get('continuous_variable')
   ipp: -> if @isPopulated() and @has('result') then @get('result').IPP else 0
-  msrpopl: -> if @isPopulated and @has('result') then @get('result').MSRPOPL else 0
+  measurePopulation: -> if @isPopulated() and @has('result') then @get('result').MSRPOPL else 0
   numerator: -> if @isPopulated() and @has('result') then @get('result').NUMER else 0
   denominator: -> if @isPopulated() and @has('result') then @get('result').DENOM else 0
-  observ: -> if @isPopulated() and @has('result') then @get('result').OBSERV else 0
+  observation: -> if @isPopulated() and @has('result') then @get('result').OBSERV else 0
   hasExceptions: -> @has('population_ids') and @get('population_ids').hasOwnProperty('DENEXCEP')
   exceptions: -> if @isPopulated() and @has('result') then @get('result').DENEXCEP else 0
   hasExclusions: -> @has('population_ids') and @get('population_ids').hasOwnProperty('DENEX')
   exclusions: -> if @isPopulated() and @has('result') then @get('result').DENEX else 0
-  hasOutliers: -> !@isContinuous and @has('antinumerator')
+  hasOutliers: -> !@isContinuous() and @has('antinumerator')
   outliers: -> if @isPopulated() and @has('result') then @get('result').antinumerator else 0
   performanceDenominator: -> @denominator() - @exceptions() - @exclusions()
   performanceRate: -> Math.round(100 * @numerator() / Math.max(1, @performanceDenominator()))

--- a/app/assets/javascripts/templates/dashboard/results.hbs
+++ b/app/assets/javascripts/templates/dashboard/results.hbs
@@ -1,15 +1,15 @@
 <div class="percent-listing">
   {{#if shouldDisplayPercentageVisual}}
-    <input type="text" value="{{performanceRate}}" class="dial" data-readOnly="true" data-width="80" data-height="80" data-thickness=".1" data-fgColor="#4B979D" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif" data-font-weight="400">
+    <input type="text" value="{{resultValue}}" class="dial" data-readOnly="true" data-width="80" data-height="80" data-thickness=".1" data-fgColor="#4B979D" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif" data-font-weight="400">
   {{else}}
-    <span class="percentage">{{performanceRate}}<small>%</small></span>
+    <span class="percentage">{{resultValue}}<small>%</small></span>
   {{/if}}
 </div>
 
 <div class="row-remainder">
   <div class="fraction-listing pull-left">
-    <div class="numerator">{{formatNumeral numerator '0.[0]a'}}</div>
-    <div class="denominator">{{formatNumeral performanceDenominator '0.[0]a'}}</div>
+    <div class="numerator">{{formatNumeral fractionTop '0.[0]a'}}</div>
+    <div class="denominator">{{formatNumeral fractionBottom '0.[0]a'}}</div>
   </div>
 
   <div class="measure-type pull-left">

--- a/app/assets/javascripts/templates/dashboard/results.hbs
+++ b/app/assets/javascripts/templates/dashboard/results.hbs
@@ -2,7 +2,7 @@
   {{#if shouldDisplayPercentageVisual}}
     <input type="text" value="{{resultValue}}" class="dial" data-readOnly="true" data-width="80" data-height="80" data-thickness=".1" data-fgColor="#4B979D" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif" data-font-weight="400">
   {{else}}
-    <span class="percentage">{{resultValue}}<small>%</small></span>
+    <span class="percentage">{{formatNumeral resultValue '0.[0]a'}}<small>{{unit}}</small></span>
   {{/if}}
 </div>
 

--- a/app/assets/javascripts/templates/patient_results/query.hbs
+++ b/app/assets/javascripts/templates/patient_results/query.hbs
@@ -1,10 +1,13 @@
-<div>
-  {{! TODO move this into a partial? }}
-  <input type="text" value="{{performanceRate}}" class="dial" data-readOnly="true" data-width="80" data-height="80" data-thickness=".1" data-fgColor="#4B979D" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif">
+<div class="percent-listing">
+  {{#if shouldDisplayPercentageVisual}}
+    <input type="text" value="{{resultValue}}" class="dial" data-readOnly="true" data-width="80" data-height="80" data-thickness=".1" data-fgColor="#4B979D" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif" data-font-weight="400">
+  {{else}}
+    <span class="percentage">{{resultValue}}<small>{{unit}}</small></span>
+  {{/if}}
 </div>
 <div class="fraction-listing pull-left">
-  <div class="numerator">{{numerator}}</div>
-  <div class="denominator">{{performanceDenominator}}</div>
+  <div class="numerator">{{fractionTop}}</div>
+  <div class="denominator">{{fractionBottom}}</div>
 </div>
 <div class="measure-type pull-left">
   <i class="{{#if episode_of_care}}fa fa-stethoscope{{else}}glyphicon glyphicon-user{{/if}}"></i>

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -17,10 +17,11 @@ class Thorax.Views.ResultsView extends Thorax.View
         @$('rect').popover()
     destroyed: ->
       clearInterval(@timeout) if @timeout?
-  shouldDisplayPercentageVisual: -> PopHealth.currentUser.shouldDisplayPercentageVisual()
+  shouldDisplayPercentageVisual: -> !@model.isContinuous() and PopHealth.currentUser.shouldDisplayPercentageVisual()
   context: (attrs) ->
     _(super).extend
-      resultValue: if @model.isContinuous() then parseFloat(@model.observ()).toFixed(1) else @model.performanceRate()
+      unit: if @model.isContinuous() and @model.parent.get('cms_id') isnt 'CMS179v2' then 'min' else '%'
+      resultValue: if @model.isContinuous() then @model.observ() else @model.performanceRate()
       fractionTop: if @model.isContinuous() then @model.msrpopl() else @model.numerator()
       fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
   initialize: ->

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -21,8 +21,8 @@ class Thorax.Views.ResultsView extends Thorax.View
   context: (attrs) ->
     _(super).extend
       unit: if @model.isContinuous() and @model.parent.get('cms_id') isnt 'CMS179v2' then 'min' else '%'
-      resultValue: if @model.isContinuous() then @model.observ() else @model.performanceRate()
-      fractionTop: if @model.isContinuous() then @model.msrpopl() else @model.numerator()
+      resultValue: if @model.isContinuous() then @model.observation() else @model.performanceRate()
+      fractionTop: if @model.isContinuous() then @model.measurePopulation() else @model.numerator()
       fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
   initialize: ->
     @popChart = PopHealth.viz.populationChart().width(125).height(40).maximumValue(PopHealth.patientCount)

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -20,10 +20,9 @@ class Thorax.Views.ResultsView extends Thorax.View
   shouldDisplayPercentageVisual: -> PopHealth.currentUser.shouldDisplayPercentageVisual()
   context: (attrs) ->
     _(super).extend
-      performanceRate: @model.performanceRate()
-      numerator: @model.numerator()
-      denominator: @model.denominator()
-      performanceDenominator: @model.performanceDenominator()
+      resultValue: if @model.isContinuous() then parseFloat(@model.observ()).toFixed(1) else @model.performanceRate()
+      fractionTop: if @model.isContinuous() then @model.msrpopl() else @model.numerator()
+      fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
   initialize: ->
     @popChart = PopHealth.viz.populationChart().width(125).height(40).maximumValue(PopHealth.patientCount)
     @model.set('providers', [@provider_id]) if @provider_id?

--- a/app/assets/javascripts/views/query_view.js.coffee
+++ b/app/assets/javascripts/views/query_view.js.coffee
@@ -6,8 +6,11 @@ class Thorax.Views.QueryView extends Thorax.View
       @$('.dial').knob()
       d3.select(@el).select('.pop-chart').datum(@model.result()).call(@popChart) if @model.isPopulated()
 
+  shouldDisplayPercentageVisual: -> !@model.isContinuous() and PopHealth.currentUser.shouldDisplayPercentageVisual()
+  resultValue: -> if @model.isContinuous() then @model.observation() else @model.performanceRate()
+  fractionTop: -> if @model.isContinuous() then @model.measurePopulation() else @model.numerator()
+  fractionBottom: -> if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
   ipp: -> @model.ipp()
-  isContinuous: -> @model.continuous_variable()
   numerator: -> @model.numerator()
   denominator: -> @model.denominator()
   hasExceptions: -> @model.hasExceptions()
@@ -19,6 +22,7 @@ class Thorax.Views.QueryView extends Thorax.View
   performanceRate: -> @model.performanceRate()
   performanceDenominator: -> @model.performanceDenominator()
   episode_of_care: -> @model.parent.get('episode_of_care')
+  unit: -> if @model.isContinuous() and @model.parent.get('cms_id') isnt 'CMS179v2' then 'min' else '%'
   initialize: ->
     @currentPopulation = 'IPP'
     @popChart = PopHealth.viz.populationChart().width(125).height(40).maximumValue(PopHealth.patientCount)

--- a/app/assets/javascripts/views/query_view.js.coffee
+++ b/app/assets/javascripts/views/query_view.js.coffee
@@ -7,6 +7,7 @@ class Thorax.Views.QueryView extends Thorax.View
       d3.select(@el).select('.pop-chart').datum(@model.result()).call(@popChart) if @model.isPopulated()
 
   ipp: -> @model.ipp()
+  isContinuous: -> @model.continuous_variable()
   numerator: -> @model.numerator()
   denominator: -> @model.denominator()
   hasExceptions: -> @model.hasExceptions()

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -141,7 +141,8 @@ $title-circle-radius: 21px;
     font-weight: 400;
     color: #4A4A4A;
     small {
-      font-size: 18px;
+      font-size: 16px;
+      padding-left: 2px;
     }
   }
 }

--- a/spec/javascripts/views/dashboard_view.spec.js.coffee
+++ b/spec/javascripts/views/dashboard_view.spec.js.coffee
@@ -11,10 +11,11 @@ describe 'Dashboard', ->
 
 describe 'Results View', ->
   beforeEach ->
-    json = loadJSONFixtures 'query.json', 'queries/patient_results.json', 'users.json'
+    json = loadJSONFixtures 'query.json', 'queries/patient_results.json', 'users.json', 'submeasure.json'
     window.PopHealth.currentUser = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
     @providerId = json['queries/patient_results.json'][0].value.provider_performances[0].provider_id
-    @query = new Thorax.Models.Query $.extend(true, {}, json['query.json']), {parent: null}
+    submeasure = new Thorax.Models.Submeasure json['submeasure.json'], parse: true
+    @query = new Thorax.Models.Query $.extend(true, {}, json['query.json']), {parent: submeasure}
     @measureId = @query.get('measure_id')
     @resultsViewWithProvider = new Thorax.Views.ResultsView model: @query, id: @measureId, provider_id: @providerId
     @resultsViewWithProvider.render()


### PR DESCRIPTION
This is the first step toward implementing support for CV measures within the dashboard, and is based heavily on the code in #134 and #183.

There is still more work to do to fully support CV/Episode of Care measures, including work on the patient page, and supporting EoC section headers for categories on the dashboard, hopefully this is a sufficient start.
