### PR TITLE
EOC and patient icon move & add popovers

### DIFF
--- a/app/assets/javascripts/templates/dashboard/results.hbs
+++ b/app/assets/javascripts/templates/dashboard/results.hbs
@@ -7,13 +7,13 @@
 </div>
 
 <div class="row-remainder">
+  <div class="measure-type pull-left">
+    <i class="{{#if episode_of_care}}fa fa-stethoscope{{else}}glyphicon glyphicon-user{{/if}}"></i>
+  </div>
+
   <div class="fraction-listing pull-left">
     <div class="numerator">{{formatNumeral fractionTop '0.[0]a'}}</div>
     <div class="denominator">{{formatNumeral fractionBottom '0.[0]a'}}</div>
-  </div>
-
-  <div class="measure-type pull-left">
-    <i class="{{#if episode_of_care}}fa fa-stethoscope{{else}}glyphicon glyphicon-user{{/if}}"></i>
   </div>
 
   <div class="pop-chart pull-left"></div>

--- a/app/assets/javascripts/templates/dashboard/results.hbs
+++ b/app/assets/javascripts/templates/dashboard/results.hbs
@@ -8,7 +8,7 @@
 
 <div class="row-remainder">
   <div class="measure-type pull-left">
-    <i class="{{#if episode_of_care}}fa fa-stethoscope{{else}}glyphicon glyphicon-user{{/if}}"></i>
+    <i class="{{#if episode_of_care}}fa fa-stethoscope{{else}}glyphicon glyphicon-user{{/if}} icon-popover" data-placement="bottom" data-content="{{#if episode_of_care}}Episodes-of-Care{{else}}Patients{{/if}}" data-trigger="hover focus"></i>
   </div>
 
   <div class="fraction-listing pull-left">

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -15,6 +15,7 @@ class Thorax.Views.ResultsView extends Thorax.View
           if PopHealth.currentUser.populationChartScaledToIPP() then @popChart.maximumValue(@model.result().IPP) else @popChart.maximumValue(PopHealth.patientCount)
           @popChart.update(_(lower_is_better: @lower_is_better).extend @model.result())
     rendered: ->
+      @$(".icon-popover").popover()
       @$('.dial').knob()
       if @model.isPopulated()
         if PopHealth.currentUser.populationChartScaledToIPP() then @popChart.maximumValue(@model.result().IPP) else @popChart.maximumValue(PopHealth.patientCount)

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -81,6 +81,7 @@ body {
       font-weight: 400;
       font-size: 12px;
       margin: 4px 0 0 -10px;
+      padding-left: 20px;
 
       .numerator,
       .denominator {


### PR DESCRIPTION
This moves the dashboard episode-of-care/patient icons to the left side of the fraction & includes popover text of either "Patients" or "Episodes-of-Care".
