### PR TITLE
downgrade bootstrap to 3.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'factory_girl', "2.6.3"
 gem 'apipie-rails'
 
 # Gems used for assets
-gem 'bootstrap-sass', '~> 3.1.1'
+gem 'bootstrap-sass', '~> 3.0.3'
 gem 'sass-rails', "~> 4.0.2"
 gem 'coffee-rails'
 gem 'jquery-rails' # necessary for jquery_ujs w/data-method="delete" etc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       rails (>= 3.0.10)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
-    bootstrap-sass (3.1.1.1)
+    bootstrap-sass (3.0.3.0)
       sass (~> 3.2)
     bson (2.3.0)
     builder (3.2.2)
@@ -272,7 +272,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   apipie-rails
-  bootstrap-sass (~> 3.1.1)
+  bootstrap-sass (~> 3.0.3)
   cancan
   coffee-rails
   devise


### PR DESCRIPTION
Bootstrap 3.1.1 has some changes that we're not ready for (for example, popovers not being anchored correctly). This kicks us back to 3.0.3.
