### PR TITLE
Removed popovers from measure headings and moved them to the info icon.

### DIFF
--- a/app/assets/javascripts/templates/dashboard/index.hbs
+++ b/app/assets/javascripts/templates/dashboard/index.hbs
@@ -91,7 +91,8 @@
             </div>
             <div class="measure-title" data-measure-sub="{{sub_id}}">
               {{#if isPrimary}}
-                <a href="#measures/{{id}}{{#if sub_id}}/{{sub_id}}{{/if}}{{#if ../../../../provider_id}}/providers/{{../../../../../provider_id}}{{/if}}" data-placement="bottom" data-content="{{description}}" data-trigger="hover focus" rel="popover">{{name}}</a>
+                <a href="#measures/{{id}}{{#if sub_id}}/{{sub_id}}{{/if}}{{#if ../../../../provider_id}}/providers/{{../../../../../provider_id}}{{/if}}">{{name}}</a>
+                <span class="glyphicon glyphicon-info-sign icon-popover" data-placement="bottom" data-content="{{description}}" data-trigger="hover focus"></span>
               {{/if}}
             </div>
           </div>

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -45,7 +45,7 @@ class Thorax.Views.DashboardSubmeasureView extends Thorax.View
     fetch: false
   events:
     rendered: ->
-      @$("[rel='popover']").popover()
+      @$(".icon-popover").popover()
       # TODO when we upgrade to Thorax 3, use `getQueryForProvider`
       query = @model.get('query')
       unless query.isPopulated()

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -129,6 +129,10 @@ body {
   .measure-title {
     padding-top: 10px;
     font-size: 16px;     // Has to be in pixels otherwise popover inherits font-size
+    .glyphicon-info-sign {
+      font-size: 14px;
+      color: #999999;
+    }
   }
   .measure-subtitle {
     padding-top: 15px;


### PR DESCRIPTION
Dashboard view measure list measure titles or measure stratification titles now include an information icon with popover text of the description of the measure or measure-stratification (same popover design as current popover). Popover text has been removed from measure title.
