### PR TITLE
Measure Detail view logic sections should be aligned correctly

### DIFF
--- a/app/assets/javascripts/templates/measures/data_criteria.hbs
+++ b/app/assets/javascripts/templates/measures/data_criteria.hbs
@@ -9,18 +9,20 @@
 {{else}}
   <div class="measure-content">
     {{#if icon}}<span class="icon-border"><i class="fa fa-2x fa-{{icon}}"></i></span>{{/if}}
-    <label>
-      {{#if specific_occurrence}}Occurrence {{specific_occurrence}}:{{/if}}
-      {{! TODO description isn't fine-grained enough; if the type is 'characteristic', use the type and title, otherwise use definition and status}}
-      {{description}}
-    </label>
-    {{title}}
-    {{#if value}}(result {{view valueView model=value}}){{/if}}
-    {{#if field_values}}
-      {{#collection field_values item-context=fieldValueContext tag="span"}}
-        <span>{{#unless isFirst}}and {{/unless}}{{title}} {{view valueView model=value}}</span>
-      {{/collection}}
-    {{/if}}
-    {{#if temporalReference}}{{view "TemporalReferenceView" model=temporalReference}}{{/if}}
+    <div>
+      <label>
+        {{#if specific_occurrence}}Occurrence {{specific_occurrence}}:{{/if}}
+        {{! TODO description isn't fine-grained enough; if the type is 'characteristic', use the type and title, otherwise use definition and status}}
+        {{description}}
+      </label>
+      {{title}}
+      {{#if value}}(result {{view valueView model=value}}){{/if}}
+      {{#if field_values}}
+        {{#collection field_values item-context=fieldValueContext tag="span"}}
+          <span>{{#unless isFirst}}and {{/unless}}{{title}} {{view valueView model=value}}</span>
+        {{/collection}}
+      {{/if}}
+      {{#if temporalReference}}{{view "TemporalReferenceView" model=temporalReference}}{{/if}}
+    </div>
   </div>
 {{/if}}

--- a/app/assets/javascripts/templates/measures/data_criteria.hbs
+++ b/app/assets/javascripts/templates/measures/data_criteria.hbs
@@ -9,7 +9,7 @@
 {{else}}
   <div class="measure-content">
     {{#if icon}}<span class="icon-border"><i class="fa fa-2x fa-{{icon}}"></i></span>{{/if}}
-    <div>
+    <div class="measure-inner">
       <label>
         {{#if specific_occurrence}}Occurrence {{specific_occurrence}}:{{/if}}
         {{! TODO description isn't fine-grained enough; if the type is 'characteristic', use the type and title, otherwise use definition and status}}

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -291,6 +291,9 @@ $table-border-color: white;
       .measure-content {
         @include clearfix;
         padding: 2px;
+        .measure-inner {
+          padding: 12px 0;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -260,11 +260,13 @@ $table-border-color: white;
     padding: 2px;
     border-radius: 10px;
     .icon-border {
+      @extend .pull-left;
       border: 2px solid #4b979d;
       border-radius: $title-circle-radius;
       color: $brand-primary;
       display: inline-block;
       line-height: $title-circle-radius * 2;
+      margin: 2px;
       text-align: center;
       height: $title-circle-radius * 2;
       width: $title-circle-radius * 2;
@@ -287,6 +289,7 @@ $table-border-color: white;
       border-radius: 10px;
       margin: 2px 2px 2px 20px;
       .measure-content {
+        @include clearfix;
         padding: 2px;
       }
     }


### PR DESCRIPTION
This PR corrects the alignment of the text to the right of the measure detail icon.
