### PR TITLE
Patient view icon size should match icon size from measure logic view

### DIFF
--- a/app/assets/stylesheets/_patient.scss
+++ b/app/assets/stylesheets/_patient.scss
@@ -73,7 +73,7 @@
     $radius: 18px;
     position: absolute;
     padding-top: 3px;
-    left: 0px;
+    left: 1px;
     background-color: white;
     border: 2px solid $brand-primary;
     border-radius: $radius;

--- a/app/assets/stylesheets/_patient.scss
+++ b/app/assets/stylesheets/_patient.scss
@@ -72,6 +72,7 @@
   .circle-icon {
     $radius: 18px;
     position: absolute;
+    padding-top: 3px;
     left: 0px;
     background-color: white;
     border: 2px solid $brand-primary;
@@ -80,6 +81,9 @@
     @include square($radius * 2);
     line-height: 2;
     text-align: center;
+    .fa {
+      font-size: 1.8em;
+    }
     &.selected {
       background-color: $brand-primary;
       color: white;


### PR DESCRIPTION
I didn't quite increase the size to the level of the measure logic view as it made the circles look way too full and caused the icons to touch the sides of the circle. If we would prefer to increase the size of the circles as well that can be done.
