### PR TITLE
Decrease font size on dashboard in order to fix IE cutoff bug.

### DIFF
--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -194,7 +194,7 @@ body {
 }
 
 .dial {
-  font-size: 26px !important;
+  font-size: 24px !important;
 }
 
 .pop-chart {


### PR DESCRIPTION
In IE, dashboard view percent font was cut off. Decreasing the dial font size compensates for this.
