### PR TITLE
update dashboard UI when measures are selected/deselected

### DIFF
--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -24,10 +24,12 @@ class Thorax.Models.User extends Thorax.Model
       return if _(@get('preferences').selected_measure_ids).any (id) -> id is measure.id
       categoryName = measure.collection.parent.get('category')
       selectedCategory = selectedCats.findWhere category: categoryName
-      unless selectedCategory?
+      isFreshlyAdded = not selectedCategory?
+      if isFreshlyAdded
         selectedCategory = new Thorax.Models.Category category: categoryName, measures: [], {parse: true}
-        selectedCats.add selectedCategory
       selectedCategory.get('measures').add measure
+      if isFreshlyAdded
+        selectedCats.add selectedCategory
       @get('preferences').selected_measure_ids.push measure.id
       @save()
 
@@ -44,10 +46,12 @@ class Thorax.Models.User extends Thorax.Model
 
     selectedCats.selectCategory = (category) =>
       selectedCategory = selectedCats.findWhere category: category.get('category')
-      unless selectedCategory?
+      isFreshlyAdded = not selectedCategory?
+      if isFreshlyAdded
         selectedCategory = new Thorax.Models.Category {category: category.get('category'), measures: []}, parse: true
-        selectedCats.add selectedCategory
       selectedCategory.get('measures').reset category.get('measures').models
+      if isFreshlyAdded
+        selectedCats.add selectedCategory
       @get('preferences').selected_measure_ids.push _(category.get('measures').pluck('id')).difference(@get('preferences').selected_measure_ids)...
       @save()
 

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -95,10 +95,24 @@ class Thorax.Views.Dashboard extends Thorax.View
     _(measure.toJSON()).extend selected: isSelected
   selectedCategoryContext: (category) ->
     # split up measures into whether or not they are continuous variable or not
-    {'true': cvMeasures, 'false': proportionBasedMeasures} = category.get('measures').groupBy 'continuous_variable'
+    measures = category.get('measures')
+    {'true': cvMeasureData, 'false': proportionBasedMeasureData} = measures.groupBy 'continuous_variable'
+    cvMeasures = new Thorax.Collections.Measures(cvMeasureData, parent: category)
+    proportionBasedMeasures = new Thorax.Collections.Measures(proportionBasedMeasureData, parent: category)
+    for action in ['add', 'remove']
+      do (action) ->
+        measures.on action, (measure) ->
+          if measure.get('continuous_variable')
+            cvMeasures[action](measure)
+          else
+            proportionBasedMeasures[action](measure)
+    measures.on 'reset', (measures) ->
+      {'true': cvMeasureData, 'false': proportionBasedMeasureData} = measures.groupBy 'continuous_variable'
+      cvMeasures.reset(cvMeasureData)
+      proportionBasedMeasures.reset(proportionBasedMeasureData)
     _(category.toJSON()).extend
-      cvMeasures:               new Thorax.Collections.Measures(cvMeasures, parent: category)
-      proportionBasedMeasures:  new Thorax.Collections.Measures(proportionBasedMeasures, parent: category)
+      cvMeasures:               cvMeasures
+      proportionBasedMeasures:  proportionBasedMeasures
 
   search: (e) ->
     $sb = $(e.target)


### PR DESCRIPTION
- Inform CV measure and proportional measure collections of changes
- Address double-rendering issue by not modifying collections twice (e.g., adding a category, then adding measures to the category)
