### PR TITLE
Update overflow setting for providerChart

### DIFF
--- a/app/assets/stylesheets/_vis.scss
+++ b/app/assets/stylesheets/_vis.scss
@@ -1,5 +1,5 @@
 #providerChart svg{
-  overflow: display;
+  overflow: visible;
   .node text{
     alignment-baseline: central;
   }


### PR DESCRIPTION
This fixes the "popHealth orphans" orphan provider text getting cut off when displayed on the dashboard page.
