### PR TITLE
Speeds up the individual patient view page

### DIFF
--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -135,7 +135,7 @@
       results.to_a.map do |result|
         hqmf_id = result['value']['measure_id']
         sub_id = result['value']['sub_id']
-        measure = HealthDataStandards::CQM::Measure.where("hqmf_id" => hqmf_id, "sub_id" => sub_id).first
+        measure = HealthDataStandards::CQM::Measure.where("hqmf_id" => hqmf_id, "sub_id" => sub_id).only(:title, :subtitle, :name).first
         result['value'].merge(measure_title: measure.title, measure_subtitle: measure.subtitle)
       end
     end


### PR DESCRIPTION
The sidebar on the individual patient view page issues a query for
each measure. Since the measure object coming back from the database
is somewhat big, these queries can take a long time. The code only
uses title and submeasure_title, so we only pull those back.
