### PR TITLE
update dashboard measure count

### DIFF
--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -133,7 +133,7 @@ class Thorax.Views.Dashboard extends Thorax.View
       $("#filters .panel-body .checkbox:containsi(#{query})").show() # show matching measures
       $("#filters .panel:containsi(#{query})").next('.panel-collapse').find('.checkbox').show() # show matching categories
 
-      $('#filters .panel-body').not(':has(.checkbox:visible)').parent().prev('.panel').hide() # hide empty category titles
+      $('#filters .panel-body').not(':has(.checkbox:visible)').parent().prev('.panel-heading').hide() # hide empty category titles
       $('#filters .panel-body').not(':has(.checkbox:visible)').hide() # hide empty category measure containers
     else
       $('#filters .panel').show() # show all category titles
@@ -156,13 +156,13 @@ class Thorax.Views.Dashboard extends Thorax.View
       @selectedCategories.selectMeasure measure
     else
       @selectedCategories.removeMeasure measure
-    $cb.closest('.panel-collapse').prev('.panel').find('.measure-count').text $cbs.filter(':checked').length
+    $cb.closest('.panel-collapse').prev('.panel-heading').find('.measure-count').text $cbs.filter(':checked').length
 
   toggleCategory: (e) ->
     # change DOM
     $cb = $(e.target)
     $cb.closest('.panel-body').find(':checkbox.individual').prop 'checked', $cb.is(':checked')
-    $measureCount = $cb.closest('.panel-collapse').prev('.panel').find('.measure-count')
+    $measureCount = $cb.closest('.panel-collapse').prev('.panel-heading').find('.measure-count')
     # change models
     category = $cb.model()
     if $cb.is(':checked')


### PR DESCRIPTION
The measure count in the filter section isn't being updated properly due to a markup change; this fixes that.

This exposes one of the issues with Thorax... it doesn't have baked-in support for updating small aspects of the UI when properties change. We got around this by using jQuery to update the UI, but this is brittle as it forces us to keep the views up to date when the markup changes, and there aren't any explicit connections between the two files.

I have some unfinished code that'll make the measure count an attribute of the category, which would be automatically rerendered on a change. This PR is a temporary fix until I can get that finished.
