### PR TITLE
wrap long words in the dashboard sidebar

### DIFF
--- a/app/assets/javascripts/templates/dashboard/index.hbs.erb
+++ b/app/assets/javascripts/templates/dashboard/index.hbs.erb
@@ -21,7 +21,7 @@
           </h4>
         </div>
         <div id="category{{@cid}}" class="panel-collapse collapse">
-          <div class="panel-body measureItemList">
+          <div class="panel-body">
             <div class="checkbox">
               <label>
                   <input type="checkbox" class="all"{{#if selected}} checked{{/if}}>
@@ -32,7 +32,7 @@
               <div class="checkbox">
                 <label>
                   <input type="checkbox" class="individual"{{#if selected}} checked{{/if}}>
-                  {{cms_id}}/{{nqf_id}} - {{name}}
+                  {{cms_id}}&#8203;/&#8203;{{nqf_id}} - {{name}}
                 </label>
               </div>
             {{/collection}}

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -8,6 +8,10 @@ body {
   margin-bottom: 40px;
 }
 
+#measureSelectors {
+  word-wrap: break-word;
+}
+
 .measure {
   @extend .row;
   .measure-title-id {


### PR DESCRIPTION
Certain words are too long for the dashboard sidebar, especially NQF numbers that are NamedLikeThis instead of just a number. This will insert soft spaces before/after the slash between the CMS and NQF IDs, as well as allow words to wrap to the next line if they still don't fit.
