### PR TITLE
Decrease padding on num/denom header. 

### DIFF
--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -113,7 +113,7 @@ body {
       font-weight: 400;
       font-size: 12px;
       margin: 4px 0 0 -10px;
-      padding-left: 20px;
+      padding-left: 7px;
 
       .numerator,
       .denominator {


### PR DESCRIPTION
This brings the column header closer to being centered over the actual text. I couldn't move the column itself since it was right up against the chart on the right. The two options I saw here were center over the actual num/denom or center over the num/denom and the icon.

![screen shot 2014-07-29 at 7 54 10 am](https://cloud.githubusercontent.com/assets/2308869/3734456/71ccd348-1717-11e4-84d5-e76b69e55bd7.png)

vs

![screen shot 2014-07-29 at 7 55 14 am](https://cloud.githubusercontent.com/assets/2308869/3734464/7959cf8a-1717-11e4-96fe-f1b86248be0f.png)

Option 1 is what I went with. If needed I can switch to option 2.
