### PR TITLE
Display measure ID (CMS ID/NQF ID) on measure detail page.

### DIFF
--- a/app/assets/javascripts/templates/measures/show.hbs
+++ b/app/assets/javascripts/templates/measures/show.hbs
@@ -3,6 +3,8 @@
 </div>
 <div class="main">
   <dl class="dl-horizontal">
+    <dt>Measure ID:</dt>
+    <dd>{{cms_id}}/{{nqf_id}}</dd>
     <dt>Measure Name:</dt>
     <dd>{{name}}</dd>
     <dt>Measurement Period:</dt>


### PR DESCRIPTION
Measure details page now includes measure ID above measure name which includes CMS id number and NQF number/text.
