### PR TITLE
Dashboard filter categories now expand no matter where you click in the category box.

### DIFF
--- a/app/assets/javascripts/templates/dashboard/index.hbs.erb
+++ b/app/assets/javascripts/templates/dashboard/index.hbs.erb
@@ -15,9 +15,7 @@
               <span class="measure-count">{{measure_count}}</span>
               <i class="panel-chevron glyphicon glyphicon-chevron-right"></i>
             </div>
-            <a class="accordion-toggle">
-              {{category}}
-            </a>
+            {{category}}
           </h4>
         </div>
         <div id="category{{@cid}}" class="panel-collapse collapse">

--- a/app/assets/javascripts/templates/dashboard/index.hbs.erb
+++ b/app/assets/javascripts/templates/dashboard/index.hbs.erb
@@ -9,13 +9,13 @@
   <div class="panel-group" id="measureSelectors">
     {{#collection item-context=categoryFilterContext item-filter=categoryFilter}}
       <div class="panel panel-default">
-        <div class="panel-heading">
+        <div class="panel-heading" data-toggle="collapse" data-parent="#measureSelectors" data-target="#category{{@cid}}">
           <h4 class="panel-title">
             <div class="selection-pull-out">
               <span class="measure-count">{{measure_count}}</span>
               <i class="panel-chevron glyphicon glyphicon-chevron-right"></i>
             </div>
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#measureSelectors" href="#category{{@cid}}">
+            <a class="accordion-toggle">
               {{category}}
             </a>
           </h4>

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -186,6 +186,13 @@ body {
 
 }
 
+// Fix for showing cursor on dashboard filters
+#measureSelectors {
+  .panel-heading {
+    cursor: pointer;
+  }
+}
+
 .percentage {
   line-height: 2.5;
   font-size: 26px;


### PR DESCRIPTION
Previously, filter category would only expand when the category name was clicked on.
