### PR TITLE
include link to provider in submeasure links

### DIFF
--- a/app/assets/javascripts/templates/dashboard/submeasure.hbs
+++ b/app/assets/javascripts/templates/dashboard/submeasure.hbs
@@ -17,7 +17,7 @@
     </div>
     <div class="measure-subtitle">
       {{#if short_subtitle}}
-        <a href="#measures/{{id}}/{{sub_id}}">{{short_subtitle}}</a>
+        <a href="#measures/{{id}}/{{sub_id}}{{#if provider_id}}/providers/{{../provider_id}}{{/if}}">{{short_subtitle}}</a>
         <span class="glyphicon glyphicon-info-sign icon-popover" data-placement="bottom" data-content="{{description}}" data-trigger="hover focus"></span>
       {{/if}}
     </div>


### PR DESCRIPTION
In #190 the provider ID was included in the main link to a measure page, but not if submeasures are present. This includes the provider ID in that case as well.
