### PR TITLE
move JS from HEAD to BODY in Users view

### DIFF
--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -1,4 +1,3 @@
-<% content_for :head do -%>
 <script type="text/javascript">
   var popHealth = popHealth || {};
 
@@ -81,7 +80,6 @@
     $('.npi_select').change(popHealth.changeNpi);
   });
 </script>
-<% end -%>
 
 <div id="pageContent">
 <h3>Users</h3>


### PR DESCRIPTION
JavaScript has been moved out of the HEAD and into the BODY; `content_for(:head)` was breaking because this had JS in the view that was placed in the HEAD.

This _doesn't_ address the same issue in the [logs](https://github.com/pophealth/popHealth/blob/25b53e15450b6c54af62e3e4cf6fdb287e75e539/app/views/logs/index.html.erb) because that needs a date picker in order to work.

This is still pretty inconsistent with the rest of the app, and hard to test, but fixes the bug. It'd be nice at some point to handle this stuff at the API level.
