### PR TITLE
be specific about when to stop listening to `change` event

### DIFF
--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -32,10 +32,14 @@ class Thorax.Views.PatientResultsView extends Thorax.View
       $(document).on 'scroll', @scrollHandler
     destroyed: ->
       $(document).off 'scroll', @scrollHandler
+      @query.off 'change', @setCollectionAndFetch
     collection:
       sync: -> @isFetching = false
 
   initialize: ->
+    @setCollectionAndFetch = =>
+      @setCollection new Thorax.Collections.PatientResults([], parent: @query, population: @population, providerId: @providerId), render: true
+      @collection.fetch()
     @isFetching = false
     @scrollHandler = =>
       distanceToBottom = $(document).height() - $(window).scrollTop() - $(window).height()
@@ -46,12 +50,8 @@ class Thorax.Views.PatientResultsView extends Thorax.View
     @setQuery @query
 
   setQuery: (query) ->
-    @query.off 'change'
+    @query.off 'change', @setCollectionAndFetch
     @query = query
     @isEpisodeOfCare = @query.parent.get('episode_of_care')
-    setCollection = =>
-      @setCollection new Thorax.Collections.PatientResults([], parent: @query, population: @population, providerId: @providerId), render: true
-      @collection.fetch()
-    @query.on 'change', setCollection
-    if @query.isNew() then @query.save() else setCollection()
-
+    @query.on 'change', @setCollectionAndFetch
+    if @query.isNew() then @query.save() else @setCollectionAndFetch()


### PR DESCRIPTION
We were turning off listening to the change event so that we didn't set up a new event listener every time we called this method without turning them off, but this was having a side-effect of turning off the change event for EVERYTHING. This gets specific about when to stop listening.
