### PR TITLE
Bumping versions and locking down QME

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.1.2'
-gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine'
+gem 'quality-measure-engine', '3.0.3'
 gem "hqmf2js", :git=> "https://github.com/pophealth/hqmf2js.git"
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git'
 #gem 'health-data-standards', :path=> '../health-data-standards'
@@ -15,7 +15,7 @@ gem 'sshkit'
 # client side pagination, this can go away.
 gem 'will_paginate'
 
-gem "active_model_serializers"
+gem "active_model_serializers", '0.8.1'
 
 gem 'json', :platforms => :jruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,12 @@
 GIT
   remote: https://github.com/pophealth/hqmf2js.git
-  revision: 71d9c742d65f0e6e2f957152dc6be76e3001c750
+  revision: 3b1a7cb957f48cc8766f515e640af60848a834e9
   specs:
     hqmf2js (1.3.0)
 
 GIT
-  remote: https://github.com/pophealth/quality-measure-engine
-  revision: 91215ee70e4a1a76111a6d944726283c5359553e
-  specs:
-    quality-measure-engine (3.0.2)
-      delayed_job_mongoid (~> 2.1.0)
-      mongoid (~> 4.0.0)
-      moped (~> 2.0.0.beta6)
-      rubyzip (~> 0.9.9)
-
-GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: c0bf708569ce3de847e47250792db935c1cb4e98
+  revision: 816912fd23fccfbe159b0c9b0c9a95dadc49ea61
   specs:
     health-data-standards (3.4.6)
       activesupport (~> 4.1.1)
@@ -35,38 +25,37 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
-    actionmailer (4.1.4)
-      actionpack (= 4.1.4)
-      actionview (= 4.1.4)
+    actionmailer (4.1.5)
+      actionpack (= 4.1.5)
+      actionview (= 4.1.5)
       mail (~> 2.5.4)
-    actionpack (4.1.4)
-      actionview (= 4.1.4)
-      activesupport (= 4.1.4)
+    actionpack (4.1.5)
+      actionview (= 4.1.5)
+      activesupport (= 4.1.5)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.4)
-      activesupport (= 4.1.4)
+    actionview (4.1.5)
+      activesupport (= 4.1.5)
       builder (~> 3.1)
       erubis (~> 2.7.0)
     active_model_serializers (0.8.1)
       activemodel (>= 3.0)
-    activemodel (4.1.4)
-      activesupport (= 4.1.4)
+    activemodel (4.1.5)
+      activesupport (= 4.1.5)
       builder (~> 3.1)
-    activerecord (4.1.4)
-      activemodel (= 4.1.4)
-      activesupport (= 4.1.4)
+    activerecord (4.1.5)
+      activemodel (= 4.1.5)
+      activesupport (= 4.1.5)
       arel (~> 5.0.0)
-    activesupport (4.1.4)
+    activesupport (4.1.5)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     ansi (1.4.3)
-    apipie-rails (0.2.1)
+    apipie-rails (0.2.5)
       json
-      rails (>= 3.0.10)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
     bootstrap-sass (3.0.3.0)
@@ -95,7 +84,7 @@ GEM
     delayed_job_mongoid (2.1.0)
       delayed_job (>= 3.0, < 5)
       mongoid (>= 3.0, < 5)
-    devise (3.2.4)
+    devise (3.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -110,12 +99,12 @@ GEM
     execjs (2.2.1)
     factory_girl (2.6.3)
       activesupport (>= 2.3.9)
-    foreman (0.74.0)
+    foreman (0.75.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    formtastic (2.2.1)
+    formtastic (2.3.0)
       actionpack (>= 3.0)
-    git (1.2.7)
+    git (1.2.8)
     handlebars_assets (0.17.1)
       execjs (>= 1.2.9)
       multi_json
@@ -130,7 +119,7 @@ GEM
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (2.0.1)
+    jasmine-core (2.0.2)
     jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -176,29 +165,34 @@ GEM
     polyglot (0.3.5)
     protected_attributes (1.0.8)
       activemodel (>= 4.0.1, < 5.0)
-    pry (0.10.0)
+    pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     pry-byebug (1.3.3)
       byebug (~> 2.7)
       pry (~> 0.10)
+    quality-measure-engine (3.0.3)
+      delayed_job_mongoid (~> 2.1.0)
+      mongoid (~> 4.0.0)
+      moped (~> 2.0.0)
+      rubyzip (~> 0.9.9)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (4.1.4)
-      actionmailer (= 4.1.4)
-      actionpack (= 4.1.4)
-      actionview (= 4.1.4)
-      activemodel (= 4.1.4)
-      activerecord (= 4.1.4)
-      activesupport (= 4.1.4)
+    rails (4.1.5)
+      actionmailer (= 4.1.5)
+      actionpack (= 4.1.5)
+      actionview (= 4.1.5)
+      activemodel (= 4.1.5)
+      activerecord (= 4.1.5)
+      activesupport (= 4.1.5)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.4)
+      railties (= 4.1.5)
       sprockets-rails (~> 2.0)
-    railties (4.1.4)
-      actionpack (= 4.1.4)
-      activesupport (= 4.1.4)
+    railties (4.1.5)
+      actionpack (= 4.1.5)
+      activesupport (= 4.1.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
@@ -251,7 +245,7 @@ GEM
       polyglot (>= 0.3.1)
     turn (0.9.6)
       ansi
-    tzinfo (1.2.1)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.5.3)
       execjs (>= 0.3.0)
@@ -270,7 +264,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers
+  active_model_serializers (= 0.8.1)
   apipie-rails
   bootstrap-sass (~> 3.0.3)
   cancan
@@ -297,7 +291,7 @@ DEPENDENCIES
   protected_attributes (~> 1.0.5)
   pry
   pry-byebug
-  quality-measure-engine!
+  quality-measure-engine (= 3.0.3)
   rails (~> 4.1.2)
   rubyzip
   sass-rails (~> 4.0.2)


### PR DESCRIPTION
Setting QME to v3.0.3
Going up to Rails 4.1.5
Bumping commits we point to on HDS and hqmf2js
Pegging active_model_serializers to 0.8.1 because 0.9 breaks the app
