### PR TITLE
adding rolify for role based access constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'jquery-rails' # necessary for jquery_ujs w/data-method="delete" etc
 gem 'uglifier'
 gem 'non-stupid-digest-assets' # support vendored non-digest assets
 
+gem 'rolify'
+
 group :test, :develop, :ci do
   gem 'pry'
   gem 'jasmine', '2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     rest-client (1.6.8)
       mime-types (~> 1.16)
       rdoc (>= 2.4.2)
+    rolify (3.4.0)
     rubyzip (0.9.9)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -299,6 +300,7 @@ DEPENDENCIES
   pry-byebug
   quality-measure-engine!
   rails (~> 4.1.2)
+  rolify
   rubyzip
   sass-rails (~> 4.0.2)
   simplecov

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -112,10 +112,10 @@ class AdminController < ApplicationController
 
     if user
       if direction == :promote
-        user.update_attribute(role, true)
+        user.add_role(role)
         render :text => "Yes - <a href=\"#\" class=\"demote\" data-role=\"#{role}\" data-username=\"#{username}\">revoke</a>"
       else
-        user.update_attribute(role, false)
+        user.remove_role(role)
         render :text => "No - <a href=\"#\" class=\"promote\" data-role=\"#{role}\" data-username=\"#{username}\">grant</a>"
       end
     else

--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -124,7 +124,7 @@
         @quality_report = QME::QualityReport.find(params[:quality_report_id])
         authorize! :read, @quality_report
         @query["provider.npi"] = {"$in" => @quality_report.filters["providers"]}
-      elsif current_user.admin?
+      elsif current_user.has_role?( :admin )
       else
          @query["provider.npi"] = current_user.npi
       end

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -83,7 +83,14 @@ module Api
     EXAMPLE
     def show
       provider_json = @provider.as_json
-      provider_json[:parent] = Provider.find(@provider.parent_id) if @provider.parent_id
+      if @provider.parent && can?(:read, @provider.parent)
+        provider_json[:parent] = Provider.find(@provider.parent_id) if @provider.parent_id
+      else
+        #clean these out so the ui does npt attempt to render them
+        provider_json[:parent] =nil
+        provider_json[:parent_id]=nil
+        provider_json[:parent_ids]=nil
+      end
       provider_json[:children] = @provider.children if @provider.children.present?
       render json: provider_json
     end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -20,7 +20,7 @@ class LogsController < ApplicationController
     end
 
     where = {}
-    where[:username] = current_user.username unless current_user.admin?
+    where[:username] = current_user.username unless current_user.has_role?( :admin )
 
     start_date = date_param_to_date(params[:log_start_date])
     if start_date

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,16 @@
+class Role
+  include Mongoid::Document
+  has_and_belongs_to_many :users
+  belongs_to :resource, :polymorphic => true
+  
+  field :name, :type => String
+
+  index({
+    :name => 1,
+    :resource_type => 1,
+    :resource_id => 1
+  },
+  { :unique => true})
+  
+  scopify
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User
 
   include ActiveModel::MassAssignmentSecurity
   include Mongoid::Document
-
+  rolify
   after_initialize :build_preferences, unless: Proc.new { |user| user.preferences.present? }
   before_save :denullify_arrays
   before_create :set_defaults
@@ -80,7 +80,7 @@ class User
   validates :username, :presence => true, length: {minimum: 3, maximum: 254}
 
   def set_defaults
-    self.staff_role ||= APP_CONFIG["default_user_staff_role"]
+    self.add_role :staff if APP_CONFIG["default_user_staff_role"]
     self.approved ||= APP_CONFIG["default_user_approved"]
     true
   end
@@ -128,7 +128,7 @@ class User
   # =============
 
   def grant_admin
-    update_attribute(:admin, true)
+    self.add_role :admin
     update_attribute(:approved, true)
   end
 
@@ -137,7 +137,16 @@ class User
   end
 
   def revoke_admin
-    update_attribute(:admin, false)
+    self.remove_role :admin
+    self[:admin]
+  end
+
+  def admin?
+    self.has_role?( :admin )
+  end
+
+  def staff_role? 
+    self.has_role?( :staff )
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,4 +149,14 @@ class User
     self.has_role?( :staff )
   end
 
+  def provider_root
+    provider = nil
+    if self.admin? || self.staff_role?
+      provider =  Provider.root 
+    else
+      provider = Provider.with_role(:staff, self).first
+    end
+    provider
+  end
+
 end

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -108,14 +108,14 @@
       </select>
     </td>
     <td>
-      <% if user.admin? -%>
+      <% if user.has_role?(:admin) -%>
       Yes - <a href="#" class="demote" data-role="admin" data-username="<%= user.username %>">revoke</a>
       <% else -%>
       No - <a href="#" class="promote" data-role="admin" data-username="<%= user.username %>">grant</a>
       <% end -%>
     </td>
     <td>
-      <% if user.staff_role? -%>
+      <% if user.has_role?(:staff) -%>
       Yes - <a href="#" class="demote" data-role="staff_role" data-username="<%= user.username %>">revoke</a>
       <% else -%>
       No - <a href="#" class="promote" data-role="staff_role" data-username="<%= user.username %>">grant</a>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,11 @@
   PopHealth.categories = <%= @categories.to_json.html_safe %>;
   PopHealth.patientCount = <%= @patient_count %>;
   PopHealth.currentUser = new Thorax.Models.User(<%= current_user.to_json({:include => :preferences }).html_safe %>);
-  PopHealth.rootProvider = new Thorax.Models.Provider(<%= Provider.root.to_json({:include => :children }).html_safe %>, {parse:true});
+  <%
+  providerRoot = Provider.root if current_user.admin? || current_user.staff_role?
+  providerRoot ||= Provider.with_role(:staff, current_user).first
+  %>
+  PopHealth.rootProvider = new Thorax.Models.Provider(<%= providerRoot.to_json({:include => :children }).html_safe %>, {parse:true});
   PopHealth.router = new PopHealth.Router();
   Backbone.history.start();
 </script>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,10 +4,12 @@
   PopHealth.patientCount = <%= @patient_count %>;
   PopHealth.currentUser = new Thorax.Models.User(<%= current_user.to_json({:include => :preferences }).html_safe %>);
   <%
-  providerRoot = Provider.root if current_user.admin? || current_user.staff_role?
-  providerRoot ||= Provider.with_role(:staff, current_user).first
+  providerRoot =  current_user.provider_root
+  providerRoot.parent_id = nil
+  providerRoot.parent_ids = nil
+
   %>
-  PopHealth.rootProvider = new Thorax.Models.Provider(<%= providerRoot.to_json({:include => :children }).html_safe %>, {parse:true});
+  PopHealth.rootProvider = new Thorax.Models.Provider(<%= providerRoot.to_json({:include => :children ,:except => :parent}).html_safe %>, {parse:true});
   PopHealth.router = new PopHealth.Router();
   Backbone.history.start();
 </script>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -22,11 +22,11 @@
               <% if APP_CONFIG['logout_enabled']%>
                 <li><%= link_to raw('<i class="glyphicon glyphicon-log-out"></i> Logout'), destroy_user_session_path, method: 'delete' %></li>
               <% end %>
-              <% if current_user.staff_role? || current_user.admin? %>
+              <% if current_user.has_role? (:staff )|| current_user.has_role?( :admin )%>
                 <li class="divider"></li>
                 <li role="presentation" class="dropdown-header">Admin</li>
                 <li><%= link_to raw('<i class="glyphicon glyphicon-plus"></i> Providers'), '/#providers'%></li>
-                <% if current_user.admin? %>
+                <% if current_user.has_role?( :admin )%>
                   <% if (APP_CONFIG['patient_management_enabled']) %>
                     <li><%= link_to raw('<i class="glyphicon glyphicon-eye-open"></i> Patients'), admin_patients_path%></li>
                   <% end %>

--- a/app/views/shared/_top_nav.html.erb
+++ b/app/views/shared/_top_nav.html.erb
@@ -2,16 +2,16 @@
   Welcome, <%= current_user.first_name.to_s %>
   <span class="sep">|</span> <a href="http://projectpophealth.org/faq.html">help</a>
   <% if APP_CONFIG['edit_account_enabled']%><span class="sep">|</span> <%= link_to 'account', edit_user_registration_path(current_user) %> <% end %>
-  <% if current_user.staff_role? || current_user.admin? %> <span class="sep">|</span> <a id="manage_link" href="javascript:void(0)">manage</a> <% end %>
+  <% if current_user.has_role?( :staff) || current_user.has_role?(:admin) %> <span class="sep">|</span> <a id="manage_link" href="javascript:void(0)">manage</a> <% end %>
   <% if APP_CONFIG['logout_enabled']%><span class="sep">|</span> <%= link_to 'logout', destroy_user_session_path, 'class' => 'log'%> <% end %>
   
   <ul id="manage-menu" class="ui-menu ui-widget ui-widget-content ui-corner-all dialog-menu" role="listbox" aria-activedescendant="ui-active-menuitem">
-    <% if current_user.staff_role? || current_user.admin? %>
+    <% if current_user.has_role?(:staff) || current_user.has_role?(:admin ) %>
     <li class="ui-menu-item" role="menuitem" data-type="providers">
       <a class="ui-corner-all" tabindex="-1" href="<%=providers_path%>">Providers</a>
     </li>
     <% end %>
-    <% if current_user.admin? %>
+    <% if current_user.has_role?(:admin) %>
       <li class="ui-menu-item" role="menuitem" data-type="users">
         <a class="ui-corner-all" tabindex="-1" href="<%=admin_users_path%>">Users</a>
       </li>

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,3 +1,4 @@
+Rolify.orm=:mongoid
 ActiveSupport.on_load(:active_model_serializers) do
   # Disable for all serializers (except ArraySerializer)
   ActiveModel::Serializer.root = false

--- a/config/initializers/mongo.rb
+++ b/config/initializers/mongo.rb
@@ -1,3 +1,4 @@
+
 MONGO_DB = Mongoid.default_session
 
 # js_collection = MONGO_DB['system.js']

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,0 +1,8 @@
+Rolify.configure do |config|
+  # By default ORM adapter is ActiveRecord. uncomment to use mongoid
+  config.use_mongoid
+  
+  # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
+  # Enable this feature _after_ running rake db:migrate as it relies on the roles table
+  # config.use_dynamic_shortcuts
+end

--- a/lib/hds/provider.rb
+++ b/lib/hds/provider.rb
@@ -1,5 +1,6 @@
 class Provider
-
+  include Mongoid::Document
+  resourcify
   field :level, type: String
   
   embeds_many :cda_identifiers, class_name: "CDAIdentifier"

--- a/lib/tasks/popHealth_users.rake
+++ b/lib/tasks/popHealth_users.rake
@@ -34,6 +34,16 @@ namespace :pophealth do
       RakeUserManager.approve ENV
     end
 
+    task :update_roles => :environment do
+      User.where(:admin=>true).each do |u|
+        u.add_role :admin
+      end
+      User.where(:staff_role=>true).each do |u|
+        u.add_role :staff
+      end
+
+    end
+
     class RakeUserManager
       def self.grant_admin(env)
         user = find_user(env)

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/fixtures/roles/admin_role.json
+++ b/test/fixtures/roles/admin_role.json
@@ -1,0 +1,10 @@
+{
+    "_id" : "admin_role",
+    "name" : "admin",
+    "resource_id" : null,
+    "resource_type" : null,
+    "user_ids" : [ 
+        "admin1",
+        "admin2"
+    ]
+}

--- a/test/fixtures/roles/staff_role.json
+++ b/test/fixtures/roles/staff_role.json
@@ -1,0 +1,12 @@
+{
+    "_id" : "staff_role",
+    "name" : "staff",
+    "resource_id" : null,
+    "resource_type" : null,
+    "user_ids" : [ 
+        "admin1",
+        "admin2",
+        "gen1",
+        "gen2"
+    ]
+}

--- a/test/fixtures/users/admin_user.json
+++ b/test/fixtures/users/admin_user.json
@@ -1,4 +1,5 @@
-{"admin":true,
+{
+  "admin":true,
  "agree_license":true,
  "approved":true,
  "company":null,
@@ -11,6 +12,9 @@
  "npi":null,
  "registry_id":null,
  "registry_name":null,
- "staff_role":true,
+ "role_ids" :[
+    "staff_role",
+    "admin_role"
+ ],
  "tin":null,
  "username":"adminuser"}

--- a/test/fixtures/users/admin_user2.json
+++ b/test/fixtures/users/admin_user2.json
@@ -1,4 +1,4 @@
-{"admin":true,
+{ "_id" : "admin2",
  "agree_license":true,
  "approved":true,
  "company":null,
@@ -11,6 +11,9 @@
  "npi":null,
  "registry_id":null,
  "registry_name":null,
- "staff_role":true,
+ "role_ids" :[
+    "staff_role",
+    "admin_role"
+ ],
  "tin":null,
  "username":"adminuser2"}

--- a/test/fixtures/users/generic_user.json
+++ b/test/fixtures/users/generic_user.json
@@ -1,4 +1,4 @@
-{"admin":false,
+{"_id" : "gen1",
  "agree_license":true,
  "approved":true,
  "company":null,
@@ -11,6 +11,8 @@
  "npi":null,
  "registry_id":null,
  "registry_name":null,
- "staff_role":true,
+ "role_ids" :[
+    "staff_role"
+ ],
  "tin":null,
  "username":"genericuser"}

--- a/test/fixtures/users/generic_user2.json
+++ b/test/fixtures/users/generic_user2.json
@@ -1,4 +1,4 @@
-{"admin":false,
+{"_id" : "gen2",
  "agree_license":true,
  "approved":true,
  "company":null,
@@ -11,6 +11,8 @@
  "npi":null,
  "registry_id":null,
  "registry_name":null,
- "staff_role":true,
+ "role_ids" :[
+    "staff_role"
+ ],
  "tin":null,
  "username":"genericuser2"}

--- a/test/fixtures/users/no_staff_role_user.json
+++ b/test/fixtures/users/no_staff_role_user.json
@@ -1,4 +1,4 @@
-{"admin":false,
+{
  "agree_license":true,
  "approved":true,
  "company":null,
@@ -11,6 +11,5 @@
  "npi":null,
  "registry_id":null,
  "registry_name":null,
- "staff_role":false,
  "tin":null,
  "username":"nostaffuser"}

--- a/test/fixtures/users/unapproved_user.json
+++ b/test/fixtures/users/unapproved_user.json
@@ -1,4 +1,4 @@
-{"admin":false,
+{
  "agree_license":true,
  "approved":false,
  "company":null,
@@ -11,6 +11,5 @@
  "npi":null,
  "registry_id":null,
  "registry_name":null,
- "staff_role":true,
  "tin":null,
  "username":"unapproved"}

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -6,7 +6,7 @@ class AdminControllerTest < ActionController::TestCase
   setup  do
 
     dump_database
-
+    collection_fixtures 'roles'
     collection_fixtures 'users'
 
     @admin = User.where({email: 'admin@test.com'}).first

--- a/test/functional/api/patients_controller_test.rb
+++ b/test/functional/api/patients_controller_test.rb
@@ -6,7 +6,7 @@ require 'test_helper'
 
     setup do
       dump_database
-      collection_fixtures 'measures', 'patient_cache', 'records', 'users'
+      collection_fixtures 'measures', 'patient_cache', 'records', 'users','roles'
       @user = User.where({email: 'admin@test.com'}).first
       sign_in @user
     end

--- a/test/functional/api/providers_controller_test.rb
+++ b/test/functional/api/providers_controller_test.rb
@@ -5,7 +5,7 @@ include Devise::TestHelpers
 
     setup do
       dump_database
-      collection_fixtures 'users', 'providers', 'measures'
+      collection_fixtures 'users', 'providers', 'measures','roles'
       @user = User.where({email: 'admin@test.com'}).first
       @provider = Provider.where({family_name: "Darling"}).first
       sign_in @user

--- a/test/functional/api/queries_controller_test.rb
+++ b/test/functional/api/queries_controller_test.rb
@@ -10,7 +10,7 @@ module Api
       collection_fixtures 'records'
       collection_fixtures 'patient_cache'
       collection_fixtures 'providers'
-      collection_fixtures 'users'
+      collection_fixtures 'users','roles'
 
       @staff = User.where({email: 'noadmin@test.com'}).first
       @admin = User.where({email: 'admin@test.com'}).first

--- a/test/functional/api/queries_controller_test.rb
+++ b/test/functional/api/queries_controller_test.rb
@@ -23,6 +23,7 @@ module Api
       @provider = Provider.where({family_name: "Darling"}).first
       @provider.npi = @npi_user.npi
       @provider.save
+      @npi_user.add_role(:staff, @provider)
 
       QME::QualityReport.where({}).each do |q|
         if q.filters

--- a/test/functional/api/reports_controller_test.rb
+++ b/test/functional/api/reports_controller_test.rb
@@ -10,7 +10,7 @@ module Api
       collection_fixtures 'records'
       collection_fixtures 'patient_cache'
       collection_fixtures 'providers'
-      collection_fixtures 'users'
+      collection_fixtures 'users','roles'
 
       @user = User.where({email: "noadmin@test.com"}).first
     end

--- a/test/functional/logs_controller_test.rb
+++ b/test/functional/logs_controller_test.rb
@@ -5,6 +5,7 @@ class LogsControllerTest < ActionController::TestCase
 
   setup do
     dump_database
+    collection_fixtures 'roles'
     collection_fixtures 'users'
 
     @user = User.where({email: 'admin@test.com'}).first

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RoleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/unit/admin_rake_test.rb
+++ b/test/unit/admin_rake_test.rb
@@ -7,7 +7,7 @@ class AdminRakeTest < ActiveSupport::TestCase
   setup do
     
     dump_database
-    
+    collection_fixtures 'roles'
     if (!@@rake)
       @@rake = Rake.application
       Rake.application = @@rake

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -4,6 +4,7 @@ class UserTest < ActiveSupport::TestCase
 
   setup do
     dump_database
+    collection_fixtures 'roles'
     collection_fixtures 'users'
 
     @user = User.where({email: 'noadmin@test.com'}).first

--- a/test/unit/user_rake_test.rb
+++ b/test/unit/user_rake_test.rb
@@ -7,6 +7,7 @@ class UserRakeTest < ActiveSupport::TestCase
   setup do
 
     dump_database
+    collection_fixtures 'roles'
     collection_fixtures 'users'
 
     @unapproved_user = User.where({email: 'unapproved@test.com'}).first


### PR DESCRIPTION
This adds in the rolify gem for role based access constraints.  This replaces/augments the simple admin and staff_role flags declared on the user model and allows for future extensibility.  
